### PR TITLE
Fix issue with services map being inserted

### DIFF
--- a/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
+++ b/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
@@ -51,26 +51,26 @@ stopifnot(file.exists(map)) # Error if the file path doesn't exist.
 # 2. Loop through each locality to create the main body of the profiles and the summary table
 for (LOCALITY in locality_list) {
   ## 2a) Source in all the scripts for a given LOCALITY
-  
+
   # demographics
   source("Demographics/1. Demographics - Population.R")
   source("./Demographics/2. Demographics - SIMD.R")
-  
+
   # housing
   source("./Households/Households Code.R")
-  
+
   # services
   source("./Services/2. Services data manipulation & table.R")
-  
+
   # general health
   source("./General Health/3. General Health Outputs.R")
-  
+
   # lifestyle & risk factors
   source("./Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R")
-  
+
   # unscheduled care
   source("./Unscheduled Care/2. Unscheduled Care outputs.R")
-  
+
   # appendices
   source("./Master RMarkdown Document & Render Code/Tables for Appendix.R")
 
@@ -78,9 +78,9 @@ for (LOCALITY in locality_list) {
   detach(package:tidylog, unload = TRUE)
 
   ## 2b) Create the main body of the profiles
-  
+
   rmarkdown::render("./Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd",
-   output_file = paste0(LOCALITY, " - Locality Profile.docx"),
+    output_file = paste0(LOCALITY, " - Locality Profile.docx"),
     output_dir = paste0(lp_path, "Master RMarkdown Document & Render Code/Output/")
   )
 

--- a/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
+++ b/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
@@ -26,21 +26,21 @@ y <- 1 # tables
 # # demographics
 # source("Demographics/Scripts/1. Demographics - Population.R")
 # source("Demographics/Scripts/2. Demographics - SIMD.R")
-# 
+#
 # # housing
 # source("Households/Scripts/Households Code.R")
-# 
+#
 # # services
 # source("Services/Scripts/2. Services data manipulation & table.R")
 # # services map (uncomment this when testing out individual localities)
 # # source("Services/Scripts/3. Service HSCP map.R")
-# 
+#
 # # general health
 # source("General Health/Scripts/3. General Health Outputs.R")
-# 
+#
 # # lifestyle & risk factors
 # source("Lifestyle & Risk Factors/Scripts/2. Lifestyle & Risk Factors Outputs.R")
-# 
+#
 # # unscheduled care
 # source("Unscheduled Care/Scripts/2. Unscheduled Care outputs.R")
 #


### PR DESCRIPTION
The HSCP service maps are manually screenshotted and stored in a folder, RMarkdown then inserts the image into the report. For some HSCPs `knitr::include_graphics` was throwing an error, `htmltools::img(map)` worked for some but would result in a finished report with no map for others.

The issue was that some images were saved with an uppercase extension e.g. `Fife.PNG` where the code was expecting a lowercase `Fife.png`. All extensions have now been made lowercase and the line `stopifnot(file.exists(map))` should throw an error much earlier (and be clearer) if there's a similar issue in future.