### PR TITLE
Remove `{tidylog}` loads

### DIFF
--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -10,10 +10,10 @@
 ############# 1) PACKAGES, DIRECTORY, LOOKUPS, DATA IMPORT + CLEANING #############
 
 ## load packages
-#library(readxl)
+# library(readxl)
 library(tidyverse)
-#library(reshape2)
-#library(knitr)
+# library(reshape2)
+# library(knitr)
 library(janitor)
 library(cowplot)
 library(gridExtra)
@@ -25,7 +25,7 @@ library(phsstyles)
 
 
 # Determine locality (for testing only)
-#LOCALITY <- "Inverness"
+# LOCALITY <- "Inverness"
 # LOCALITY <- "Stirling City with the Eastern Villages Bridge of Allan and Dunblane"
 # LOCALITY <- "Mid-Argyll, Kintyre and Islay"
 # LOCALITY <- "City of Dunfermline"
@@ -38,7 +38,7 @@ ext_year <- 2023
 lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 
 # Source in functions code
-#source("Master RMarkdown Document & Render Code/Global Script.R")
+# source("Master RMarkdown Document & Render Code/Global Script.R")
 
 ### Geographical lookups and objects ----
 

--- a/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
+++ b/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
@@ -15,7 +15,7 @@
 
 ## load packages
 library(readxl)
-library(tidyverse)#review and either load in global or only specific 
+library(tidyverse) # review and either load in global or only specific
 library(reshape2)
 library(janitor)
 library(png)
@@ -27,7 +27,7 @@ library(grid)
 library(phsstyles)
 
 # Determine locality (for testing only)
-#LOCALITY <- "Falkirk West"
+# LOCALITY <- "Falkirk West"
 # LOCALITY <- "Stirling City with the Eastern Villages Bridge of Allan and Dunblane"
 # LOCALITY <- "Mid-Argyll, Kintyre and Islay"
 # LOCALITY <- "City of Dunfermline"
@@ -40,7 +40,7 @@ ext_year <- 2023
 lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 
 # Source in functions code
-#source("Master RMarkdown Document & Render Code/Global Script.R")
+# source("Master RMarkdown Document & Render Code/Global Script.R")
 
 ### Geographical lookups and objects ----
 
@@ -98,7 +98,7 @@ bowel_screening <- readRDS(paste0(lp_path, "Lifestyle & Risk Factors/Data ", ext
 
 check_missing_data_scotpho(bowel_screening)
 
-###check if there is any drug death data 
+### check if there is any drug death data
 
 ############################### 2) OUTPUTS ####################################
 
@@ -133,8 +133,8 @@ drug_hosp_bar <- drug_hosp %>%
 
 drug_hosp_bar
 
-###review piping style for consistency 
-## Numbers for text 
+### review piping style for consistency
+## Numbers for text
 
 drug_hosp_latest <- filter(
   drug_hosp,

--- a/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
+++ b/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
@@ -28,8 +28,8 @@ lookup <- read_in_localities()
 HSCP_list <- unique(lookup$hscp2019name)
 
 # Create list of localities in chosen HSCP
-locality_list <- lookup |> 
-  filter(hscp2019name == HSCP) |> 
+locality_list <- lookup |>
+  filter(hscp2019name == HSCP) |>
   pull(hscp_locality)
 
 

--- a/Unscheduled Care/1. Unscheduled Care data extraction.R
+++ b/Unscheduled Care/1. Unscheduled Care data extraction.R
@@ -35,9 +35,9 @@ library(arrow)
 source("./Master RMarkdown Document & Render Code/Global Script.R")
 
 # Read/write permissions
-#Sys.umask("006")
+# Sys.umask("006")
 
-#Sys.getenv("R_ZIPCMD", "zip")
+# Sys.getenv("R_ZIPCMD", "zip")
 
 # Folder to export to
 exportfolder <- paste0(lp_path, "Unscheduled Care/DATA ", ext_year, "/")

--- a/Unscheduled Care/2. Unscheduled Care outputs.R
+++ b/Unscheduled Care/2. Unscheduled Care outputs.R
@@ -26,14 +26,14 @@ library(haven)
 library(fst)
 
 
-### for testing run global script and locality placeholder below 
+### for testing run global script and locality placeholder below
 
 ## Functions
-#source("./Master RMarkdown Document & Render Code/Global Script.R")
+# source("./Master RMarkdown Document & Render Code/Global Script.R")
 
 ## Define locality
 # LOCALITY <- "Stirling City with the Eastern Villages Bridge of Allan and Dunblane"
-#LOCALITY <- "Inverness"
+# LOCALITY <- "Inverness"
 # LOCALITY <- "Ayr North and Former Coalfield Communities"
 # LOCALITY <- "Whalsay and Skerries"
 # LOCALITY <- "North Perthshire"
@@ -71,10 +71,10 @@ populations <- read_in_dz_pops()
 
 populations22 <- read_in_dz_pops22()
 
-populations <- rbind(populations,populations22)
+populations <- rbind(populations, populations22)
 
 
-#pop_max_year <- max(populations$year)
+# pop_max_year <- max(populations$year)
 
 # compute age bands
 populations$"Pop0_17" <- rowSums(subset(populations, select = age0:age17))


### PR DESCRIPTION
This package should only be used for development and therefore should not be in the production code.