### PR TITLE
Clean up the environment after each iteration of the loop (v2)

### DIFF
--- a/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
+++ b/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
@@ -48,6 +48,8 @@ map <- paste0(lp_path, "Master RMarkdown Document & Render Code/Output/maps/", H
 
 stopifnot(file.exists(map)) # Error if the file path doesn't exist.
 
+loop_env <- c(ls(), "loop_env")
+
 # 2. Loop through each locality to create the main body of the profiles and the summary table
 for (LOCALITY in locality_list) {
   ## 2a) Source in all the scripts for a given LOCALITY
@@ -89,4 +91,9 @@ for (LOCALITY in locality_list) {
     output_file = paste0(LOCALITY, " - Summary Table.docx"),
     output_dir = paste0(lp_path, "Master RMarkdown Document & Render Code/Output/Summary Tables/")
   )
+  
+  # Clean up the environment by restoring it to the 'pre-loop' state.
+  rm(list = setdiff(ls(), loop_env))
+  # Force garbage collection to free up memory
+  gc()
 }


### PR DESCRIPTION
This is a repeat of #78 but with the issue fixed!

The previous one worked for the first iteration of the loop, but then it was deleting the `loop_env` object so at the end of a subsequent iteration it would not be able to 'work out' which objects to keep and which should be removed

```r
rm(list = setdiff(ls(), loop_env))
```

This is the line at the end of the loop which essentially finds the list of objects in the environment which weren't in the environment before the loop started (`setdiff`) and then removes them (`rm(list = x)` where `x` is a character vector with names of objects.

I tested this on a 3 Locality HSCP (Orkney Isles) and it didn't throw any errors and the output also seems fine. This was with the default 4096 MB RAM! 