### PR TITLE
Tidy the SMR connection code

### DIFF
--- a/Unscheduled Care/1. Unscheduled Care data extraction.R
+++ b/Unscheduled Care/1. Unscheduled Care data extraction.R
@@ -222,13 +222,11 @@ query_deaths <- paste(
 
 
 # Connect to ODBC
-channel <- suppressWarnings(
-  dbConnect(
-    drv = odbc::odbc(),
-    dsn = "SMRA",
-    uid = rstudioapi::showPrompt(title = "Username", message = "Username:"),
-    pwd = .rs.askForPassword("What is your LDAP password?")
-  )
+channel <- odbc::dbConnect(
+  drv = odbc::odbc(),
+  dsn = "SMRA",
+  uid = Sys.getenv("USER"),
+  pwd = rstudioapi::askForPassword("Enter LDAP password:")
 )
 
 # Run queries

--- a/Unscheduled Care/MH_pub_code/001_SMR01SMR04_basefile.R
+++ b/Unscheduled Care/MH_pub_code/001_SMR01SMR04_basefile.R
@@ -78,11 +78,12 @@ future_date <- "2029-01-01"
 
 ### 5 - Define the database connection with SMRA ----
 # set it up so that a pop up appears to enter user name and password
-suppressWarnings(channel <- dbConnect(odbc(),
+channel <- odbc::dbConnect(
+  drv = odbc::odbc(),
   dsn = "SMRA",
-  uid = .rs.askForPassword("SMRA Username:"),
-  pwd = .rs.askForPassword("SMRA Password:")
-))
+  uid = Sys.getenv("USER"),
+  pwd = rstudioapi::askForPassword("Enter LDAP password:")
+)
 
 
 ###################################

--- a/Unscheduled Care/MH_pub_code/MH_emergencyadmissions_query.R
+++ b/Unscheduled Care/MH_pub_code/MH_emergencyadmissions_query.R
@@ -9,13 +9,11 @@ query_smr4 <- paste(
   "FROM ANALYSIS.SMR04_PI WHERE (DISCHARGE_DATE >= TO_DATE('2016-04-01','YYYY-MM-DD'))"
 )
 
-channel <- suppressWarnings(
-  dbConnect(
-    drv = odbc::odbc(),
-    dsn = "SMRA",
-    uid = rstudioapi::showPrompt(title = "Username", message = "Username:"),
-    pwd = .rs.askForPassword("What is your LDAP password?")
-  )
+channel <- odbc::dbConnect(
+  drv = odbc::odbc(),
+  dsn = "SMRA",
+  uid = Sys.getenv("USER"),
+  pwd = rstudioapi::askForPassword("Enter LDAP password:")
 )
 
 smr4_extract <- as_tibble(dbGetQuery(channel,


### PR DESCRIPTION
This is a minor QOL change that's probably only relevant in `1. Unscheduled Care data extraction.R`. It uses `Sys.getenv("USER")` to get the username from the system environment, so only the password is required to be entered.

I just copy/pasted to make sure it's the same code in all locations to avoid any confusion as to why one is different from another.