### PR TITLE
Remove obsolete commented code

### DIFF
--- a/.github/workflows/style-modified-files.yaml
+++ b/.github/workflows/style-modified-files.yaml
@@ -68,3 +68,4 @@ jobs:
         with:
           commit_message: "Style code"
           file_pattern: '*.R *.Rmarkdown'
+          skip_checkout: true

--- a/Demographics/1. Demographics - Population.R
+++ b/Demographics/1. Demographics - Population.R
@@ -20,24 +20,17 @@ library(janitor)
 library(readxl)
 library(reshape2)
 library(scales)
-# library(rgdal)
 library(broom)
-# library(OpenStreetMap)
-# library(ggrepel)
 library(phsstyles)
 
 # Source in global functions/themes script
-# source("./Master RMarkdown Document & Render Code/Global Script.R")
-
-## File path
-filepath <- "./RMarkdown/Locality Profiles/Demographics/"
+#  source("./Master RMarkdown Document & Render Code/Global Script.R")
 
 ## Final document will loop through a list of localities
 # Create placeholder for for loop
 # LOCALITY <- "Inverness"
 # LOCALITY <- "Stirling City with the Eastern Villages Bridge of Allan and Dunblane"
 # LOCALITY <- "Ayr North and Former Coalfield Communities"
-
 
 
 ########################## SECTION 2: Data Imports ###############################
@@ -158,7 +151,7 @@ pop_pyramid <- ggplot(
     limits = max(pop_breakdown$Population) * c(-1, 1)
   ) +
   scale_fill_manual(values = palette) +
-  theme_profiles() + # guides(fill = FALSE)
+  theme_profiles() +
   labs(
     x = "Population",
     y = "Age Group",
@@ -488,11 +481,3 @@ scot_over65 <- pop_scot %>%
   pull(perc_over65)
 
 rm(pop_hscp, pop_scot)
-
-
-
-# detach(package:tidyverse, unload=TRUE)
-# detach(package:ggrepel, unload=TRUE)
-# detach(package:reshape2, unload=TRUE)
-# detach(package:rgdal, unload=TRUE)
-# detach(package:janitor, unload=TRUE)

--- a/Demographics/2. Demographics - SIMD.R
+++ b/Demographics/2. Demographics - SIMD.R
@@ -33,12 +33,6 @@ library(sf)
 # Source in global functions/themes script
 # source("./Master RMarkdown Document & Render Code/Global Script.R")
 
-## File path
-filepath <- paste0(
-  "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/",
-  "RMarkdown/Locality Profiles/Demographics/"
-)
-
 ## Final document will loop through a list of localities
 # Create placeholder for for loop
 # LOCALITY <-  "Skye, Lochalsh and West Ross"
@@ -262,11 +256,6 @@ simd_map_data <- simd2020 %>%
 # merge with shapefile
 zones <- merge(zones, simd_map_data, by = "datazone2011")
 
-# convert to df for ggplot and add data back on
-# zones_tidy <- tidy(zones)
-# zones$id <- row.names(zones)
-# zones_tidy <- left_join(zones_tidy, zones@data)
-
 # set colours for simd
 simd_col <- c("#de4243", "#f6bf87", "#ffffc2", "#b9e1eb", "#4f81bd")
 simd_cats <- c(
@@ -292,9 +281,6 @@ simd_map <- ggplot() +
     color = "black", size = 3.5,
     max.overlaps = getOption("ggrepel.max.overlaps", default = 12)
   ) +
-  #
-  # scale_x_continuous(limits = c(min(zones_tidy$long), max(zones_tidy$long))) +
-  # scale_y_continuous(limits = c(min(zones_tidy$lat), max(zones_tidy$lat))) +
   theme_void() +
   guides(fill = guide_legend(title = "SIMD Quintile")) +
   labs(caption = "Source: Scottish Government, Public Health Scotland")
@@ -528,10 +514,3 @@ hscp_simd <- pop_data %>%
 
 hscp_simd_top <- filter(hscp_simd, simd2020v2_sc_quintile == 5)$perc
 hscp_simd_bottom <- filter(hscp_simd, simd2020v2_sc_quintile == 1)$perc
-
-
-# detach(package:tidyverse, unload=TRUE)
-# detach(package:ggrepel, unload=TRUE)
-# detach(package:reshape2, unload=TRUE)
-# detach(package:rgdal, unload=TRUE)
-# detach(package:janitor, unload=TRUE)

--- a/General Health/2. General Health SLF Data.R
+++ b/General Health/2. General Health SLF Data.R
@@ -30,13 +30,7 @@ fy <- "202223"
 lookup <- read_in_localities(dz_level = TRUE)
 
 # Read in SLF individual level file
-# slf <- read.fst(paste0(
-#  "/conf/hscdiip/01-Source-linkage-files/",
-#  "source-individual-file-", fy, ".fst"
-# )) %>%
-#  select(-locality, -hscp2019, -hb2019)
-
-slf <- slfhelper::read_slf_individual("2223",
+slf <- read_slf_individual("2223",
   col_select = c("year", "datazone2011", "hscp2018", "age", "keep_population", ltc_vars),
   as_data_frame = TRUE
 )
@@ -58,7 +52,6 @@ slf$age_group <- case_when(
 
 ltc_agg <- slf %>%
   left_join(lookup, by = "datazone2011") %>%
-  # drop_na(Locality) %>%
   group_by(year, hscp2019name, hscp_locality, age_group, total_ltc) %>%
   summarise(
     arth = sum(arth),

--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -10,17 +10,12 @@
 ############# 1) PACKAGES, DIRECTORY, LOOKUPS, DATA IMPORT + CLEANING #############
 
 ## load packages
-# library(readxl)
 library(tidyverse)
-# library(reshape2)
-# library(knitr)
 library(janitor)
 library(cowplot)
 library(gridExtra)
 library(grid)
 library(png)
-
-# library(tidylog)
 library(phsstyles)
 
 

--- a/Households/Households Code.R
+++ b/Households/Households Code.R
@@ -44,7 +44,7 @@ filepath <- paste0("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/
 # source("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Master RMarkdown Document & Render Code/Global Script.R")
 
 # Set locality (for testing only)
-## LOCALITY = "Whalsay and Skerries"
+# LOCALITY <- "Whalsay and Skerries"
 # LOCALITY <- "Ayr North and Former Coalfield Communities"
 
 
@@ -368,12 +368,3 @@ scot_perc_housesFH <- format_number_for_text(sum(house_raw_dat2$council_tax_band
   house_raw_dat2$council_tax_band_h,
   na.rm = TRUE
 ) / sum(house_raw_dat2$total_number_of_dwellings, na.rm = TRUE) * 100)
-
-
-
-#
-# detach(package:tidyverse, unload=TRUE)
-# detach(package:maps, unload=TRUE)
-# detach(package:reshape2, unload=TRUE)
-# detach(package:gridExtra, unload=TRUE)
-# detach(package:janitor, unload=TRUE)

--- a/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
+++ b/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
@@ -23,7 +23,6 @@ library(cowplot)
 library(knitr)
 library(gridExtra)
 library(grid)
-# library(tidylog)
 library(phsstyles)
 
 # Determine locality (for testing only)
@@ -401,10 +400,3 @@ scot_alcohol_hosp <- round_half_up(scot_alcohol_hosp, 1)
 scot_alcohol_deaths <- round_half_up(scot_alcohol_deaths, 1)
 
 scot_bowel_screening <- round_half_up(scot_bowel_screening, 1)
-
-
-
-# detach(package:tidyverse, unload=TRUE)
-# detach(package:reshape2, unload=TRUE)
-# detach(package:janitor, unload=TRUE)
-# detach(package:ggthemes, unload=TRUE)

--- a/Master RMarkdown Document & Render Code/Global Script.R
+++ b/Master RMarkdown Document & Render Code/Global Script.R
@@ -17,11 +17,6 @@ library(lubridate)
 
 #### Colours & Formatting ####
 
-# Installing phsstyles:
-# remotes::install_github("Public-Health-Scotland/phsstyles",
-#                         upgrade = "never"
-# )
-
 ## PHS colour palette from phsstyles
 palette <- phsstyles::phs_colours(c(
   "phs-purple", "phs-magenta", "phs-blue", "phs-green",

--- a/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
+++ b/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
@@ -70,9 +70,6 @@ for (LOCALITY in locality_list) {
   # appendices
   source("./Master RMarkdown Document & Render Code/Tables for Appendix.R")
 
-  # Remove tidylog package which messes up outputs
-  # detach(package:tidylog, unload = TRUE)
-
   ## 1b) Create the main body of the profiles
 
   rmarkdown::render("./Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd",

--- a/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
+++ b/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
@@ -15,45 +15,14 @@ output:
 knitr::opts_chunk$set(echo = TRUE)
 options(kableExtra.auto_format = FALSE)
 
-## Project file path
-# lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
-
-# Line below for testing only
-# LOCALITY <- "Moray East"
-
 # Figure and table number objects
 x <- 1 # figures
 y <- 1 # tables
-
-# # demographics
-# source("Demographics/Scripts/1. Demographics - Population.R")
-# source("Demographics/Scripts/2. Demographics - SIMD.R")
-#
-# # housing
-# source("Households/Scripts/Households Code.R")
-#
-# # services
-# source("Services/Scripts/2. Services data manipulation & table.R")
-# # services map (uncomment this when testing out individual localities)
-# # source("Services/Scripts/3. Service HSCP map.R")
-#
-# # general health
-# source("General Health/Scripts/3. General Health Outputs.R")
-#
-# # lifestyle & risk factors
-# source("Lifestyle & Risk Factors/Scripts/2. Lifestyle & Risk Factors Outputs.R")
-#
-# # unscheduled care
-# source("Unscheduled Care/Scripts/2. Unscheduled Care outputs.R")
-#
-# # appendices
-# source("Master RMarkdown Document & Render Code/Tables for Appendix.R")
 
 library(tidyverse)
 library(knitr)
 library(gridExtra)
 library(grid)
-# detach(package:tidylog, unload = TRUE)
 ```
 
 ##### Page break

--- a/Master RMarkdown Document & Render Code/Tables for Appendix.R
+++ b/Master RMarkdown Document & Render Code/Tables for Appendix.R
@@ -28,7 +28,6 @@ indicator_defs <- read_excel(paste0(lp_path, "Project Info & Indicators/Indicato
 indicator_defs$format <- "**"
 indicator_defs$Indicator <- paste0(indicator_defs$format, indicator_defs$Indicator, indicator_defs$format)
 
-# indicator_defs <- as_tibble(indicator_defs)
 indicator_defs <- dplyr::select(indicator_defs, -format)
 
 

--- a/Services/2. Services data manipulation & table.R
+++ b/Services/2. Services data manipulation & table.R
@@ -191,9 +191,3 @@ services_tibble <- tibble(
     nrow(other_care_type)
   )
 )
-
-
-# detach(package:tidyverse, unload=TRUE)
-# detach(package:janitor, unload=TRUE)
-# detach(package:mapview, unload=TRUE)
-# detach(package:data.table, unload=TRUE)

--- a/Services/3. Service HSCP map.R
+++ b/Services/3. Service HSCP map.R
@@ -14,7 +14,7 @@
 # source("Master RMarkdown Document & Render Code/Global Script.R")
 
 ## Select a locality based on the HSCP (for source code "2. Services Outputs" to run - it does not matter which one is chosen)
-# LOCALITY <- as.character(filter(read_in_localities(), hscp2019name == HSCP)[1, 1])
+# LOCALITY <- read_in_localities() |> filter(hscp2019name == HSCP) |> slice(1) |> pull(hscp_locality)
 
 # Source the data manipulation script for services
 # source("Services/2. Services data manipulation & table.R")


### PR DESCRIPTION
I've tried to trim out all of the non-useful, non-controversial commented code. The bits of commented code that are left are either bits used for testing purposes, or a handful of big blocks of code that *might* be useful in the future.