### PR TITLE
Cleanup file paths

### DIFF
--- a/Demographics/Demographics-Testing-Markdown.Rmd
+++ b/Demographics/Demographics-Testing-Markdown.Rmd
@@ -2,8 +2,8 @@
 title: ''
 output:
   word_document:
-    reference_docx: //conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
-      Profiles/Master RMarkdown Document & Render Code/Locality_Profiles_Report_Template.docx
+    reference_docx: "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
+      Profiles/Master RMarkdown Document & Render Code/Locality_Profiles_Report_Template.docx"
   html_document:
     df_print: paged
 ---
@@ -22,8 +22,8 @@ options(kableExtra.auto_format = FALSE)
 # LOCALITY <- "City of Dunfermline"
 LOCALITY <- "Inverness"
 
-source("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Demographics/Scripts/1. Demographics - Population.R")
-source("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Demographics/Scripts/2. Demographics - SIMD.R")
+source("Demographics/Scripts/1. Demographics - Population.R")
+source("Demographics/Scripts/2. Demographics - SIMD.R")
 
 x <- 1 # object for figure numbers
 y <- 1 # object for table numbers

--- a/General Health/General-Health-Testing-Markdown.Rmd
+++ b/General Health/General-Health-Testing-Markdown.Rmd
@@ -2,8 +2,8 @@
 title: ''
 output:
   word_document:
-    reference_docx: //conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
-      Profiles/Master RMarkdown Document & Render Code/Locality_Profiles_Report_Template.docx
+    reference_docx: "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
+      Profiles/Master RMarkdown Document & Render Code/Locality_Profiles_Report_Template.docx"
   html_document:
     df_print: paged
 ---

--- a/Households/Households Code.R
+++ b/Households/Households Code.R
@@ -38,10 +38,10 @@ max_year_housing <- 2022
 ext_year <- 2023
 
 # Set Directory.
-filepath <- paste0("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Households/")
+# lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 
 # Read in Global Script for RMarkdown (For testing only)
-# source("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Master RMarkdown Document & Render Code/Global Script.R")
+# source("Master RMarkdown Document & Render Code/Global Script.R")
 
 # Set locality (for testing only)
 ## LOCALITY = "Whalsay and Skerries"
@@ -54,9 +54,9 @@ filepath <- paste0("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/
 
 house_raw_dat <- data.frame()
 
-# get historic housing data, each year is on a seperate sheet so do a for loop
+# get historic housing data, each year is on a separate sheet so do a for loop
 for (i in 2014:max_year_housing) {
-  temp <- read_excel(paste0(filepath, "Data ", ext_year, "/household_estimates.xlsx"),
+  temp <- read_excel(paste0(lp_path, "Households/", "Data ", ext_year, "/household_estimates.xlsx"),
     sheet = paste(i), skip = 3
   ) %>%
     mutate(year = i) %>%
@@ -144,7 +144,7 @@ house_table <- house_dat1 %>%
 
 # https://www.nrscotland.gov.uk/statistics-and-data/statistics/statistics-by-theme/households/household-estimates/small-area-statistics-on-households-and-dwellings
 
-house_raw_dat2 <- read_excel(paste0(filepath, "Data ", ext_year, "/council_tax.xlsx"),
+house_raw_dat2 <- read_excel(paste0(lp_path, "Households/", "Data ", ext_year, "/council_tax.xlsx"),
   sheet = as.character(max_year_housing), skip = 4
 ) %>%
   clean_names()

--- a/Households/Housing-Markdown.Rmd
+++ b/Households/Housing-Markdown.Rmd
@@ -2,8 +2,8 @@
 title: ''
 output:
   word_document:
-    reference_docx: //conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
-      Profiles/Master RMarkdown Document & Render Code/Locality_Profiles_Report_Template.docx
+    reference_docx: "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
+      Profiles/Master RMarkdown Document & Render Code/Locality_Profiles_Report_Template.docx"
   html_document:
     df_print: paged
 ---
@@ -21,7 +21,7 @@ options(kableExtra.auto_format = FALSE)
 # LOCALITY <- "Skye, Lochalsh and West Ross"
 # LOCALITY <- "Ayr North and Former Coalfield Communities"
 
-source("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Households/Scripts/Households Code.R")
+source("Households/Households Code.R")
 
 x <- 1 # object for figure numbers
 y <- 1 # object for table numbers

--- a/Lifestyle & Risk Factors/Lifestyle-Risk-Factors-Testing-Markdown.Rmd
+++ b/Lifestyle & Risk Factors/Lifestyle-Risk-Factors-Testing-Markdown.Rmd
@@ -2,8 +2,8 @@
 title: ''
 output:
   word_document:
-    reference_docx: //conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
-      Profiles/Master RMarkdown Document & Render Code/Locality_Profiles_Report_Template.docx
+    reference_docx: "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
+      Profiles/Master RMarkdown Document & Render Code/Locality_Profiles_Report_Template.docx"
   html_document:
     df_print: paged
 ---

--- a/Master RMarkdown Document & Render Code/Global Script.R
+++ b/Master RMarkdown Document & Render Code/Global Script.R
@@ -2,8 +2,8 @@
 
 # Contains various settings and functions to be used in other locality profile scripts
 
-# How to read in:
-# source("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Master RMarkdown Document & Render Code/Global Script.R)
+# How to use this script:
+# source("Master RMarkdown Document & Render Code/Global Script.R)
 
 ## Packages for functions (** note - should this contain all packages necessary for locality profiles?
 # and automatically installing missing packages?)

--- a/Master RMarkdown Document & Render Code/excel_output.r
+++ b/Master RMarkdown Document & Render Code/excel_output.r
@@ -156,4 +156,4 @@ openxlsx::writeData(wb, sheet = 'Index', x = index_data)
 
 
 # Save the workbook to a file
-openxlsx::saveWorkbook(wb, paste0("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/background data/",HSCP,".xlsx"), overwrite = TRUE)
+openxlsx::saveWorkbook(wb, paste0(lp_path, "background data/", HSCP, ".xlsx"), overwrite = TRUE)

--- a/Services/3. Service HSCP map.R
+++ b/Services/3. Service HSCP map.R
@@ -102,7 +102,7 @@ places <- read_csv(paste0(
   filter(type != "hamlet" & type != "village")
 
 # 3.3 Background map ----
-locality_map_id <- read_csv("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Services/locality_map_id.csv")
+locality_map_id <- read_csv(paste0(lp_path, "Services/", "locality_map_id.csv"))
 api_key <- locality_map_id$id
 # upload map background from stadia maps, enter registration key, filter for max and min long/lat
 register_stadiamaps(key = api_key)

--- a/Summary Table/Summary-Table-Markdown.Rmd
+++ b/Summary Table/Summary-Table-Markdown.Rmd
@@ -2,7 +2,7 @@
 title: ''
 output: 
   word_document:
-    reference_docx: "//conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Summary Table/ST_ref_doc.docx"
+    reference_docx: "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Summary Table/ST_ref_doc.docx"
 ---
 
 ```{r setup, include = FALSE}


### PR DESCRIPTION
I changed some file paths where they were incorrectly pointing to old versions of scripts we have on the stats drive.

I made better use of the `lp_path` object in a few places.