### PR TITLE
Fix the axis on the LTC prevalence plot

### DIFF
--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -757,11 +757,11 @@ ltc_plot_right <- ltc_types %>%
   expand_limits(x = lims.ov65) +
   theme_profiles() +
   theme(
+    title = element_text(colour = palette[2]),
     plot.margin = unit(c(0.5, 0, 0, 0), "cm"),
-    axis.title.x = element_blank(),
-    axis.text.x = element_blank(),
-    axis.ticks.x = element_blank(),
-    title = element_text(colour = palette[2])
+    axis.title.y = element_blank(),
+    axis.text.y = element_blank(),
+    axis.ticks.y = element_blank(),
   ) +
   scale_y_discrete(limits = rev(levels(as.factor(ltc_types$key))))
 

--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -728,7 +728,7 @@ ltc_plot_left <- ltc_types %>%
   geom_point(colour = palette[1], size = 3) +
   geom_segment(aes(x = 0, y = key, xend = percent, yend = key), size = 0.4) +
   labs(x = "People under 65 with\nthe condition (%)", y = "", title = "UNDER 65") +
-  scale_x_continuous(breaks = seq(-100, 0, 2), labels = paste0(seq(100, 0, -2))) +
+  scale_x_continuous(breaks = seq(-100, 0, 2), labels = abs) +
   expand_limits(x = lims.un65) +
   theme_profiles() +
   theme(

--- a/General Health/General-Health-Testing-Markdown.Rmd
+++ b/General Health/General-Health-Testing-Markdown.Rmd
@@ -21,6 +21,8 @@ LOCALITY <- "Inverness"
 # LOCALITY <- "Skye, Lochalsh and West Ross"
 # LOCALITY <- "East Dunbartonshire West"
 
+# Set file path
+lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 
 source("~/localities/Master RMarkdown Document & Render Code/Global Script.R")
 

--- a/General Health/General-Health-Testing-Markdown.Rmd
+++ b/General Health/General-Health-Testing-Markdown.Rmd
@@ -24,13 +24,14 @@ LOCALITY <- "Inverness"
 # Set file path
 lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 
-source("~/localities/Master RMarkdown Document & Render Code/Global Script.R")
-
-source("~/localities//General Health/3. General Health Outputs.R")
-
+source("Master RMarkdown Document & Render Code/Global Script.R")
 
 x <- 1 # object for figure numbers
 y <- 1 # object for table numbers
+```
+
+```{r produce_data, include = FALSE}
+source("General Health/3. General Health Outputs.R")
 ```
 
 #####Page break


### PR DESCRIPTION
This was (yet another) a mistake introduced in #69, it resolves #125

Before:
![image](https://github.com/user-attachments/assets/a905c09f-8acd-4243-94bc-774bea5d2a2a)

After:
![image](https://github.com/user-attachments/assets/b46bc86e-d24d-4a8d-a6b6-b16cece32962)
