### PR TITLE
Reorder the headings for Table 8

### DIFF
--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -394,9 +394,19 @@ highest_hosp_disease <- disease_hosp %>%
   filter(area_name == LOCALITY & area_type == "Locality") %>%
   filter(measure == max(measure))
 
-disease_hosp_table <- disease_hosp %>%
-  select(indicator, period_short, area_name, measure) %>%
-  pivot_wider(names_from = area_name, values_from = measure) %>%
+disease_hosp_table <- disease_hosp |>
+  mutate(
+    area_order = case_when(
+      area_name == LOCALITY ~ 1L,
+      area_name == HSCP ~ 2L,
+      str_starts(area_name, "NHS") ~ 4L,
+      area_name == "Scotland" ~ 5L,
+      .default = 2L
+    )
+  ) |>
+  arrange(area_order) |> 
+  select(indicator, period_short, area_name, measure) |> 
+  pivot_wider(names_from = area_name, values_from = measure) |>
   rename(
     "Disease" = indicator,
     "Latest time period" = period_short

--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -203,14 +203,12 @@ life_exp_table <- life_exp %>%
     year == latest_year_life_exp_otherareas &
       ((area_name == HSCP & area_type == "HSCP") |
         area_name == HB | area_name == "Scotland")) %>%
-  select("Sex" = sex, area_name, area_type, measure) %>%
-  mutate(measure = round_half_up(measure, 1)) %>%
   mutate(
-    area_type = factor(area_type, levels = c("Locality", "HSCP", "Health board", "Scotland")),
-    area_name = fct_reorder(as.factor(area_name), as.numeric(area_type))
+    measure = round_half_up(measure, 1),
+    area_type = ordered(area_type, levels = c("Locality", "HSCP", "Health board", "Scotland"))
   ) %>%
-  arrange(area_name) %>%
-  select(-area_type) %>%
+  arrange(area_type) %>%
+  select("Sex" = sex, area_name, measure) %>%
   pivot_wider(names_from = area_name, values_from = measure)
 
 

--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -402,8 +402,8 @@ disease_hosp_table <- disease_hosp |>
       .default = 2L
     )
   ) |>
-  arrange(area_order) |> 
-  select(indicator, period_short, area_name, measure) |> 
+  arrange(area_order) |>
+  select(indicator, period_short, area_name, measure) |>
   pivot_wider(names_from = area_name, values_from = measure) |>
   rename(
     "Disease" = indicator,

--- a/General Health/General-Health-Testing-Markdown.Rmd
+++ b/General Health/General-Health-Testing-Markdown.Rmd
@@ -21,6 +21,8 @@ LOCALITY <- "Inverness"
 # LOCALITY <- "Skye, Lochalsh and West Ross"
 # LOCALITY <- "East Dunbartonshire West"
 
+# Set file path
+lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 
 source("~/localities/Master RMarkdown Document & Render Code/Global Script.R")
 

--- a/General Health/General-Health-Testing-Markdown.Rmd
+++ b/General Health/General-Health-Testing-Markdown.Rmd
@@ -24,13 +24,14 @@ LOCALITY <- "Inverness"
 # Set file path
 lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 
-source("~/localities/Master RMarkdown Document & Render Code/Global Script.R")
-
-source("~/localities//General Health/3. General Health Outputs.R")
-
+source("Master RMarkdown Document & Render Code/Global Script.R")
 
 x <- 1 # object for figure numbers
 y <- 1 # object for table numbers
+```
+
+```{r produce_data, include = FALSE}
+source("General Health/3. General Health Outputs.R")
 ```
 
 #####Page break


### PR DESCRIPTION
Resolves #126

The substantive changes are to `disease_hosp_table` I looked at `life_exp_table` first to see how it was ordering the headings (it's using a variable `area_type` that isn't available otherwise).