### PR TITLE
Allow looping over multiple / all HSCPs

### DIFF
--- a/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
+++ b/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
@@ -18,73 +18,77 @@ lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
 # Source in functions code
 source("Master RMarkdown Document & Render Code/Global Script.R")
 
-## Specify HSCP here
-## NOTE - make sure that the formatting of the partnership's name matches the lookup
-HSCP <- "Angus"
-
 # Below creates locality list of all the localities in a chosen HSCP
 lookup <- read_in_localities()
 
-HSCP_list <- unique(lookup$hscp2019name)
+# Specify HSCP(s) ----
+# use `unique(lookup$hscp2019name)` for all
+hscp_list <- "Angus"
 
-# Create list of localities in chosen HSCP
-locality_list <- lookup |>
-  filter(hscp2019name == HSCP) |>
-  pull(hscp_locality)
+# NOTE - This checks that it exactly matches the lookup
+stopifnot(all(hscp_list %in% unique(lookup$hscp2019name)))
 
+# Loop over HSCP ----
+# 'looping' over one HSCP is fine.
+for (HSCP in hscp_list) {
+  # Create list of localities in chosen HSCP
+  locality_list <- lookup |>
+    filter(hscp2019name == HSCP) |>
+    pull(hscp_locality)
 
-## Loop to create the profiles for all the localities in the list
+  # Loop to create the profiles for all the localities in the list
 
-## There are several stages to the profiles:
-# 1. Looping through each locality in the HSCP doing the following:
-# 1a. Run each section script for that locality
-# 1b. Run the Rmd for the main body of the profiles
-# 1c. Run the Rmd for the summary tables
+  # There are several stages to the profiles:
+  # 1. Looping through each locality in the HSCP doing the following:
+  # 1a. Run each section script for that locality
+  # 1b. Run the Rmd for the main body of the profiles
+  # 1c. Run the Rmd for the summary tables
 
-loop_env <- c(ls(), "loop_env")
+  loop_env <- c(ls(), "loop_env")
 
-# 1. Loop through each locality to create the main body of the profiles and the summary table
-for (LOCALITY in locality_list) {
-  ## 1a) Source in all the scripts for a given LOCALITY
+  # 1. Loop through each locality to create the main body of the profiles and the summary table
+  for (LOCALITY in locality_list) {
+    # 1a) Source in all the scripts for a given LOCALITY
 
-  # demographics
-  source("Demographics/1. Demographics - Population.R")
-  source("Demographics/2. Demographics - SIMD.R")
+    demographics
+    source("Demographics/1. Demographics - Population.R")
+    source("Demographics/2. Demographics - SIMD.R")
 
-  # housing
-  source("Households/Households Code.R")
+    # housing
+    source("Households/Households Code.R")
 
-  # services
-  source("Services/2. Services data manipulation & table.R")
-  source("Services/3. Service HSCP map.R")
+    # services
+    source("Services/2. Services data manipulation & table.R")
+    source("Services/3. Service HSCP map.R")
 
-  # general health
-  source("General Health/3. General Health Outputs.R")
+    # general health
+    source("General Health/3. General Health Outputs.R")
 
-  # lifestyle & risk factors
-  source("Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R")
+    # lifestyle & risk factors
+    source("Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R")
 
-  # unscheduled care
-  source("Unscheduled Care/2. Unscheduled Care outputs.R")
+    # unscheduled care
+    source("Unscheduled Care/2. Unscheduled Care outputs.R")
 
-  # appendices
-  source("Master RMarkdown Document & Render Code/Tables for Appendix.R")
+    # appendices
+    source("Master RMarkdown Document & Render Code/Tables for Appendix.R")
 
-  ## 1b) Create the main body of the profiles
+    # 1b) Create the main body of the profiles
 
-  rmarkdown::render("Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd",
-    output_file = paste0(LOCALITY, " - Locality Profile.docx"),
-    output_dir = paste0(lp_path, "Master RMarkdown Document & Render Code/Output/")
-  )
+    rmarkdown::render("Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd",
+      output_file = paste0(LOCALITY, " - Locality Profile.docx"),
+      output_dir = paste0(lp_path, "Master RMarkdown Document & Render Code/Output/")
+    )
 
-  ## 1c) Create the summary tables
-  rmarkdown::render("Summary Table/Summary-Table-Markdown.Rmd",
-    output_file = paste0(LOCALITY, " - Summary Table.docx"),
-    output_dir = paste0(lp_path, "Master RMarkdown Document & Render Code/Output/Summary Tables/")
-  )
+    ## 1c) Create the summary tables
+    rmarkdown::render("Summary Table/Summary-Table-Markdown.Rmd",
+      output_file = paste0(LOCALITY, " - Summary Table.docx"),
+      output_dir = paste0(lp_path, "Master RMarkdown Document & Render Code/Output/Summary Tables/")
+    )
 
-  # Clean up the environment by restoring it to the 'pre-loop' state.
-  rm(list = setdiff(ls(), loop_env))
-  # Force garbage collection to free up memory
-  gc()
+    # Clean up the environment by restoring it to the 'pre-loop' state.
+    rm(list = setdiff(ls(), loop_env))
+    # Force garbage collection to free up memory
+    gc()
+  }
 }

--- a/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
+++ b/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
@@ -23,6 +23,7 @@ lookup <- read_in_localities()
 
 # Specify HSCP(s) ----
 # use `unique(lookup$hscp2019name)` for all
+# or create a vector for multiple e.g. `c("Angus", "West Lothian")`
 hscp_list <- "Angus"
 
 # NOTE - This checks that it exactly matches the lookup

--- a/Master RMarkdown Document & Render Code/excel_output.r
+++ b/Master RMarkdown Document & Render Code/excel_output.r
@@ -19,137 +19,141 @@ lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
 # Source in functions code
 source("Master RMarkdown Document & Render Code/Global Script.R")
 
-# Below creates locality list of all the localities in a chosen HSCP
-lookup <- read_in_localities()
+# Specify HSCP(s) ----
+# use `unique(lookup$hscp2019name)` for all
+hscp_list <- c("Angus")
 
-# Add HSCP name
-HSCP_list <- c("South Ayrshire") # unique(lookup$hscp2019name)
+# NOTE - This checks that it exactly matches the lookup
+stopifnot(all(hscp_list %in% unique(lookup$hscp2019name)))
 
-# Create list of localities in chosen HSCP
-locality_list <- lookup %>%
-  filter(hscp2019name %in% HSCP_list) %>%
-  pull(hscp_locality)
+# Loop over HSCP ----
+# 'looping' over one HSCP is fine.
+for (HSCP in hscp_list) {
+  # Create list of localities in chosen HSCP
+  locality_list <- lookup |>
+    filter(hscp2019name == HSCP) |>
+    pull(hscp_locality)
+
+  ## Loop to create the profiles for all the localities in the list
 
 
-## Loop to create the profiles for all the localities in the list
+  # Determine the number of outputs
+  # num_outputs <- length(demo_list(LOCALITY[[1]]))
 
+  # Create an empty list to store dataframes for each output
+  excel_output <- vector("list", length = 38)
 
-# Determine the number of outputs
-# num_outputs <- length(demo_list(LOCALITY[[1]]))
+  # excel_output <- list()
 
-# Create an empty list to store dataframes for each output
-excel_output <- vector("list", length = 38)
+  # 2. Loop through each locality to create the appended excel output
+  for (LOCALITY in locality_list) {
+    ## 2a) Source in all the scripts for a given LOCALITY
 
-# excel_output <- list()
+    # demographics
+    source("Demographics/1. Demographics - Population.R")
+    source("Demographics/2. Demographics - SIMD.R")
+    # lifestyle & risk factors
+    source("Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R")
 
-# 2. Loop through each locality to create the appended excel output
-for (LOCALITY in locality_list) {
-  ## 2a) Source in all the scripts for a given LOCALITY
+    # unscheduled care
+    source("Unscheduled Care/2. Unscheduled Care outputs.R")
 
-  # demographics
-  source("Demographics/1. Demographics - Population.R")
-  source("Demographics/2. Demographics - SIMD.R")
-  # lifestyle & risk factors
-  source("Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R")
+    # general health
+    source("General Health/3. General Health Outputs.R")
 
-  # unscheduled care
-  source("Unscheduled Care/2. Unscheduled Care outputs.R")
+    # housing
+    source("Households/Households Code.R")
 
-  # general health
-  source("General Health/3. General Health Outputs.R")
+    # services
+    source("Services/2. Services data manipulation & table.R")
 
-  # housing
-  source("Households/Households Code.R")
+    # Define data frames and their corresponding sheet names
+    df <- list(
+      "Population_Estimates" = pops[pops$hscp_locality == LOCALITY, ],
+      "Population_Projections" = pop_proj_dat,
+      "SIMD_Locality_2021" = simd_perc_breakdown,
+      "SIMD_Domains_2016" = simd2016_dom,
+      "SIMD_Domains_2021" = simd2020_dom,
+      "Care_Home" = markers_care_home[markers_care_home$hscp_locality == LOCALITY, ],
+      "Emergency_Dep" = markers_emergency_dep[markers_emergency_dep$hscp_locality == LOCALITY, ],
+      "GP" = markers_gp[markers_gp$hscp_locality == LOCALITY, ],
+      "Minor_Injuries_Unit" = markers_miu[markers_miu$hscp_locality == LOCALITY, ],
+      "Housing_Data" = house_dat1,
+      "Housing_Council_Tax_Band" = house_dat2,
+      "Life_Expectancy" = life_exp[life_exp$area_name == LOCALITY, ],
+      "Deaths_Aged_15_44" = deaths_15_44[deaths_15_44$area_name == LOCALITY, ],
+      "Cancer_Registrations" = cancer_reg[cancer_reg$area_name == LOCALITY, ],
+      "Early_Deaths_Cancer" = early_deaths_cancer[early_deaths_cancer$area_name == LOCALITY, ],
+      "Asthma_Hospitalisations" = asthma_hosp[asthma_hosp$area_name == LOCALITY, ],
+      "CHD_Hospitalisations" = chd_hosp[chd_hosp$area_name == LOCALITY, ],
+      "COPD_Hospitalisations" = copd_hosp[copd_hosp$area_name == LOCALITY, ],
+      "MH_Prescritpions" = adp_presc[adp_presc$area_name == LOCALITY, ],
+      "Long_Term_Conditions" = ltc[ltc$hscp_locality == LOCALITY, ],
+      "Alcohol_Admissions_2122" = alcohol_hosp[alcohol_hosp$area_name == LOCALITY, ],
+      "Alcohol_Deaths_2017-2021" = alcohol_deaths[alcohol_deaths$area_name == LOCALITY, ],
+      "Drug_Admissions_1920-2122" = drug_hosp[drug_hosp$area_name == LOCALITY, ],
+      "Bowel_Screening_2019-2021" = bowel_screening[bowel_screening$area_name == LOCALITY, ],
+      "Emergency_Admissions" = emergency_adm_areas[emergency_adm_areas$location == LOCALITY, ],
+      "Emergency_Admissions_Age " = emergency_adm_age[emergency_adm_age$hscp_locality == LOCALITY, ],
+      "Unscheduled_Bed_Days" = bed_days_areas[bed_days_areas$location == LOCALITY, ],
+      "Unscheduled_Bed_Days_Age" = bed_days_age[bed_days_age$hscp_locality == LOCALITY, ],
+      "Readmissions" = readmissions_areas[readmissions_areas$location == LOCALITY, ],
+      "Readmissions_Age" = readmissions_age,
+      "AE_attendances" = ae_att_areas[ae_att_areas$location == LOCALITY, ],
+      "AE_attendances_Age" = ae_att_age[ae_att_age$hscp_locality == LOCALITY, ],
+      "Delayed_Discharge" = delayed_disch_areas[delayed_disch_areas$location == LOCALITY, ],
+      "Fall_Admissions" = falls_areas[falls_areas$location == LOCALITY, ], # Need to add Scotland & HB to this
+      "Preventable_admission_PPA" = ppa_areas[ppa_areas$location == LOCALITY, ], # Need to add Scotland & HB to this
+      "psych_admissions" = psych_hosp[psych_hosp$area_name == LOCALITY, ], # Need to add Scotland & HB to this
+      "MH_bed_days" = bed_days_mh_areas[bed_days_mh_areas$location == LOCALITY, ],
+      "bed_days_mh_age" = bed_days_mh_age[bed_days_mh_age$hscp_locality == LOCALITY, ]
+    )
 
-  # services
-  source("Services/2. Services data manipulation & table.R")
+    # Loop over each dataframe in the df list to add locality and append to the output list
+    for (i in seq_along(df)) {
+      # Get the current dataframe
+      output <- df[[i]]
 
-  # Define data frames and their corresponding sheet names
-  df <- list(
-    "Population_Estimates" = pops[pops$hscp_locality == LOCALITY, ],
-    "Population_Projections" = pop_proj_dat,
-    "SIMD_Locality_2021" = simd_perc_breakdown,
-    "SIMD_Domains_2016" = simd2016_dom,
-    "SIMD_Domains_2021" = simd2020_dom,
-    "Care_Home" = markers_care_home[markers_care_home$hscp_locality == LOCALITY, ],
-    "Emergency_Dep" = markers_emergency_dep[markers_emergency_dep$hscp_locality == LOCALITY, ],
-    "GP" = markers_gp[markers_gp$hscp_locality == LOCALITY, ],
-    "Minor_Injuries_Unit" = markers_miu[markers_miu$hscp_locality == LOCALITY, ],
-    "Housing_Data" = house_dat1,
-    "Housing_Council_Tax_Band" = house_dat2,
-    "Life_Expectancy" = life_exp[life_exp$area_name == LOCALITY, ],
-    "Deaths_Aged_15_44" = deaths_15_44[deaths_15_44$area_name == LOCALITY, ],
-    "Cancer_Registrations" = cancer_reg[cancer_reg$area_name == LOCALITY, ],
-    "Early_Deaths_Cancer" = early_deaths_cancer[early_deaths_cancer$area_name == LOCALITY, ],
-    "Asthma_Hospitalisations" = asthma_hosp[asthma_hosp$area_name == LOCALITY, ],
-    "CHD_Hospitalisations" = chd_hosp[chd_hosp$area_name == LOCALITY, ],
-    "COPD_Hospitalisations" = copd_hosp[copd_hosp$area_name == LOCALITY, ],
-    "MH_Prescritpions" = adp_presc[adp_presc$area_name == LOCALITY, ],
-    "Long_Term_Conditions" = ltc[ltc$hscp_locality == LOCALITY, ],
-    "Alcohol_Admissions_2122" = alcohol_hosp[alcohol_hosp$area_name == LOCALITY, ],
-    "Alcohol_Deaths_2017-2021" = alcohol_deaths[alcohol_deaths$area_name == LOCALITY, ],
-    "Drug_Admissions_1920-2122" = drug_hosp[drug_hosp$area_name == LOCALITY, ],
-    "Bowel_Screening_2019-2021" = bowel_screening[bowel_screening$area_name == LOCALITY, ],
-    "Emergency_Admissions" = emergency_adm_areas[emergency_adm_areas$location == LOCALITY, ],
-    "Emergency_Admissions_Age " = emergency_adm_age[emergency_adm_age$hscp_locality == LOCALITY, ],
-    "Unscheduled_Bed_Days" = bed_days_areas[bed_days_areas$location == LOCALITY, ],
-    "Unscheduled_Bed_Days_Age" = bed_days_age[bed_days_age$hscp_locality == LOCALITY, ],
-    "Readmissions" = readmissions_areas[readmissions_areas$location == LOCALITY, ],
-    "Readmissions_Age" = readmissions_age,
-    "AE_attendances" = ae_att_areas[ae_att_areas$location == LOCALITY, ],
-    "AE_attendances_Age" = ae_att_age[ae_att_age$hscp_locality == LOCALITY, ],
-    "Delayed_Discharge" = delayed_disch_areas[delayed_disch_areas$location == LOCALITY, ],
-    "Fall_Admissions" = falls_areas[falls_areas$location == LOCALITY, ], # Need to add Scotland & HB to this
-    "Preventable_admission_PPA" = ppa_areas[ppa_areas$location == LOCALITY, ], # Need to add Scotland & HB to this
-    "psych_admissions" = psych_hosp[psych_hosp$area_name == LOCALITY, ], # Need to add Scotland & HB to this
-    "MH_bed_days" = bed_days_mh_areas[bed_days_mh_areas$location == LOCALITY, ],
-    "bed_days_mh_age" = bed_days_mh_age[bed_days_mh_age$hscp_locality == LOCALITY, ]
-  )
+      # Add locality name to the output dataframe
+      output$locality <- LOCALITY
 
-  # Loop over each dataframe in the df list to add locality and append to the output list
-  for (i in seq_along(df)) {
-    # Get the current dataframe
-    output <- df[[i]]
-
-    # Add locality name to the output dataframe
-    output$locality <- LOCALITY
-
-    # Combine the current dataframe with existing dataframes for the same output
-    excel_output[[i]] <- rbind(excel_output[[i]], output) # append(excel_output[[i]], output)
+      # Combine the current dataframe with existing dataframes for the same output
+      excel_output[[i]] <- rbind(excel_output[[i]], output) # append(excel_output[[i]], output)
+    }
   }
+
+  wb <- openxlsx::createWorkbook()
+
+  names(excel_output) <- names(df)
+
+  excel_names <- names(df)
+
+
+
+  # Loop over each combined dataframe
+  for (i in seq_along(excel_output)) {
+    # Get the current combined dataframe
+    output <- excel_output[[i]]
+
+    # Get the dataframe name
+    dataframe_name <- excel_names[[i]]
+
+    # Create a new sheet with the dataframe name as the sheet name
+    openxlsx::addWorksheet(wb, sheetName = dataframe_name)
+
+    # Write the combined dataframe to the current sheet
+    openxlsx::writeData(wb, sheet = dataframe_name, x = output)
+  }
+
+  index_data <- data.frame(Sheet_name = excel_names)
+
+  excel_output <- c(index_data, excel_output)
+
+  openxlsx::addWorksheet(wb, sheetName = "Index")
+
+  openxlsx::writeData(wb, sheet = "Index", x = index_data)
+
+
+  # Save the workbook to a file
+  openxlsx::saveWorkbook(wb, paste0(lp_path, "background data/", HSCP, ".xlsx"), overwrite = TRUE)
 }
-
-wb <- openxlsx::createWorkbook()
-
-names(excel_output) <- names(df)
-
-excel_names <- names(df)
-
-
-
-# Loop over each combined dataframe
-for (i in seq_along(excel_output)) {
-  # Get the current combined dataframe
-  output <- excel_output[[i]]
-
-  # Get the dataframe name
-  dataframe_name <- excel_names[[i]]
-
-  # Create a new sheet with the dataframe name as the sheet name
-  openxlsx::addWorksheet(wb, sheetName = dataframe_name)
-
-  # Write the combined dataframe to the current sheet
-  openxlsx::writeData(wb, sheet = dataframe_name, x = output)
-}
-
-index_data <- data.frame(Sheet_name = excel_names)
-
-excel_output <- c(index_data, excel_output)
-
-openxlsx::addWorksheet(wb, sheetName = "Index")
-
-openxlsx::writeData(wb, sheet = "Index", x = index_data)
-
-
-# Save the workbook to a file
-openxlsx::saveWorkbook(wb, paste0(lp_path, "background data/", HSCP, ".xlsx"), overwrite = TRUE)


### PR DESCRIPTION
This should allow looping over any number of HSCPs, but the main use case would be sequentially producing a set of LPs for every HSCP.

Instead of setting `HSCP` we would now set `hscp_list` with one of:
* `hscp_list <- "Angus"` for a single HSCP
* `hscp_list <- c("Angus", "West Lothian")` for multiple HSCPs
* `hscp_list <- unique(lookup$hscp2019name)` for *all* HSCPs

The loop then sets `HSCP` to a single HSCP, as this variable is used in many places that expect it to be a single value.

I also added a check using `stopifnot()` this will throw an error if the HSCP isn't in the lookup (likely a typo etc.)