### PR TITLE
Use `linewidth` instead of `size` with `ggplot2::geom_line()`

### DIFF
--- a/Demographics/1. Demographics - Population.R
+++ b/Demographics/1. Demographics - Population.R
@@ -288,7 +288,7 @@ pop_plot_dat <- rbind(
   mutate(plot_lab = if_else(year %% 2 == 0, format(pop, big.mark = ","), ""))
 
 pop_ts_plot <- ggplot(pop_plot_dat, aes(x = year, y = pop)) +
-  geom_line(aes(color = data), size = 1) +
+  geom_line(aes(color = data), linewidth = 1) +
   geom_point(color = "#0f243e") +
   geom_text(aes(label = plot_lab),
     vjust = 2, color = "#4a4a4a", size = 3

--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -175,7 +175,7 @@ life_exp_trend <- life_exp %>%
   mutate(period_short = str_wrap(period_short, width = 10)) %>%
   mutate(measure = round_half_up(measure, 1)) %>%
   ggplot(aes(x = period_short, y = measure, group = sex, linetype = sex, shape = sex)) +
-  geom_line(aes(colour = sex), size = 1) +
+  geom_line(aes(colour = sex), linewidth = 1) +
   geom_point(aes(colour = sex), size = 2) +
   scale_colour_manual(values = palette) +
   theme_profiles() +

--- a/Master RMarkdown Document & Render Code/Global Script.R
+++ b/Master RMarkdown Document & Render Code/Global Script.R
@@ -309,7 +309,7 @@ scotpho_time_trend <- function(data, chart_title, xaxis_title, yaxis_title, stri
       x = str_wrap(period_short, width = string_wrap), y = measure,
       group = area_name, fill = area_name, linetype = area_type
     )) +
-    geom_line(aes(colour = area_name), size = 1) +
+    geom_line(aes(colour = area_name), linewidth = 1) +
     geom_point(aes(colour = area_name), size = 2) +
     geom_ribbon(
       aes(
@@ -360,7 +360,7 @@ scotpho_time_trend_HSCP <- function(data, chart_title, xaxis_title, yaxis_title,
       x = str_wrap(period_short, width = string_wrap), y = measure,
       group = area_name, fill = area_name, linetype = area_type
     )) +
-    geom_line(aes(colour = area_name), size = 1) +
+    geom_line(aes(colour = area_name), linewidth = 1) +
     geom_point(aes(colour = area_name), size = 2) +
     geom_ribbon(
       aes(

--- a/Unscheduled Care/2. Unscheduled Care outputs.R
+++ b/Unscheduled Care/2. Unscheduled Care outputs.R
@@ -242,7 +242,7 @@ aggregate_usc_area_data <- function(data) {
 age_group_trend_usc <- function(data_for_plot, plot_title, yaxis_title, source) {
   data_for_plot %>%
     ggplot(aes(x = financial_year, y = data, group = age_group, color = age_group)) +
-    geom_line(size = 1) +
+    geom_line(linewidth = 1) +
     geom_point() +
     scale_colour_manual(values = c(palette)) +
     scale_x_discrete(breaks = data_for_plot$financial_year) +
@@ -263,7 +263,7 @@ area_trend_usc <- function(data_for_plot, plot_title, yaxis_title, source) {
     mutate(location = fct_reorder(as.factor(str_wrap(location, 23)), as.numeric(area_type))) %>%
     ggplot() +
     aes(x = financial_year, y = data, group = location, fill = location, linetype = area_type) +
-    geom_line(aes(colour = location), size = 1) +
+    geom_line(aes(colour = location), linewidth = 1) +
     geom_point(aes(colour = location), size = 2) +
     scale_fill_manual(values = palette) +
     scale_colour_manual(values = palette) +


### PR DESCRIPTION
Using `size` aesthetic for lines was deprecated in ggplot2 3.4.0 but this is a like-for-like replacement.