### PR TITLE
Dec 24 release/general health data update

### DIFF
--- a/General Health/1. Save GH ScotPHO data as parquet.R
+++ b/General Health/1. Save GH ScotPHO data as parquet.R
@@ -10,7 +10,7 @@ library(readr)
 library(arrow)
 
 # Change year to be the year in the data folder name
-ext_year <- 2023
+ext_year <- 2024
 
 # Set file path
 lp_path <- path("/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles")

--- a/General Health/1. Save GH ScotPHO data as parquet.R
+++ b/General Health/1. Save GH ScotPHO data as parquet.R
@@ -19,21 +19,53 @@ gen_health_data_dir <- path(lp_path, "General Health", glue("DATA {ext_year}"))
 # Error if the directory doesn't exist
 stopifnot(dir_exists(gen_health_data_dir))
 
-# Map over every CSV file in the directory
-dir_ls(path = gen_health_data_dir, type = "file", regexp = ".csv", fixed = TRUE) |>
-  # For each file
-  # 1) Read the data
-  # 2) Write it out as a compressed parquet file
-  # 3) Delete the original CSV file
-  walk(
-    function(file_path) {
-      read_csv(file_path, show_col_types = FALSE) |>
-        write_parquet(path_ext_set(file_path, "parquet"), compression = "zstd")
+data_extract_file <- dir_ls(gen_health_data_dir, glob = "*ScotPHO_datatab_extract_*")
 
-      file_delete(file_path)
-    },
+# Error if there's not a single file
+stopifnot(file_exists(data_extract_file))
+stopifnot(length(data_extract_file) == 1)
+
+# Read the data and split (nest) it by indicator so we can write out each one separately
+read_rds(data_extract_file) |>
+  nest(.by = indicator) |>
+  mutate(
+    # Put the indicator column back in the data
+    data = map2(
+      data,
+      indicator,
+      \(data, indicator) mutate(data, indicator = indicator)
+    ),
+    # Use the indicator to determine the file name
+    file_name = paste0(
+      "scotpho_data_extract_",
+      case_match(
+        indicator,
+        "Asthma patient hospitalisations" ~ "asthma_hosp",
+        "Cancer registrations" ~ "cancer_reg",
+        "Chronic obstructive pulmonary disease (COPD) patient hospitalisations" ~ "copd_hosp",
+        "Coronary heart disease (CHD) patient hospitalisations" ~ "chd_hosp",
+        "Deaths, aged 15-44 years" ~ "deaths_15_44",
+        "Early deaths from cancer, aged <75 years" ~ "early_deaths_cancer",
+        "Life expectancy, females" ~ "life_exp_fem",
+        "Life expectancy, males" ~ "life_exp_male",
+        "Population prescribed drugs for anxiety/depression/psychosis" ~ "adp_presc",
+        .default = NA_character_
+      ),
+      ".parquet"
+    )
+  ) |>
+  # Write each indicator's data to individual files
+  pwalk(
+    \(indicator, data, file_name) write_parquet(
+      data,
+      path(gen_health_data_dir, file_name),
+      compression = "zstd"
+    ),
     .progress = TRUE
   )
+
+# Delete the original data extract
+file_delete(data_extract_file)
 
 # Clean up the environment
 rm(list = ls())

--- a/General Health/2. General Health SLF Data.R
+++ b/General Health/2. General Health SLF Data.R
@@ -5,11 +5,11 @@
 # Set-up ----
 
 # Set year for data extracts folder for saving
-ext_year <- 2023
+ext_year <- 2024
 
 # Set financial year to use for SLFs (format ex: for FY 2021/2022 -> 202122)
 # Recommended to use previous year's data for more up to date figures + pop
-fy <- "2223"
+fy <- "2324"
 
 # Source in functions code
 source("Master RMarkdown Document & Render Code/Global Script.R")

--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -22,7 +22,7 @@ library(png)
 # LOCALITY <- "Barra"
 
 # Set year of data extracts for folder
-ext_year <- 2023
+ext_year <- 2024
 
 # Source in functions code
 # source("Master RMarkdown Document & Render Code/Global Script.R")


### PR DESCRIPTION
A few updates to use the new (2024) data folder, and to use the 23/24 SLF file.

Since the updated ScotPHO dashboard allows (easily) downloading a custom file with multiple indicators, I updated the code to use this. The process would now be:

- Download all the GH indicators as a single (RDS) file
- Run `General Health/1. Save GH ScotPHO data as parquet.R`

`General Health/1. Save GH ScotPHO data as parquet.R` now takes that big file and writes out each indicator as its own parquet file, matching the previous file names.


I'm thinking we can expand this idea (#135) and download a single file from ScotPHO with all indicators, then use the same code to write the individual indicators to the relevant folders (i.e. where the current code expects to find them. 