### PR TITLE
Find outlier HSPCs for testing

### DIFF
--- a/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
+++ b/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
@@ -22,6 +22,9 @@ lookup <- read_in_localities()
 # Specify HSCP(s) ----
 # use `unique(lookup$hscp2019name)` for all
 # or create a vector for multiple e.g. `c("Angus", "West Lothian")`
+# For a larger test, use the below to produce profiles for HSCPs likely to cause issues.
+# source("Master RMarkdown Document & Render Code/find_hscp_outliers.R")
+# hscp_list <- outlier_hscps
 hscp_list <- "Angus"
 
 # NOTE - This checks that it exactly matches the lookup

--- a/Master RMarkdown Document & Render Code/find_hscp_outliers.R
+++ b/Master RMarkdown Document & Render Code/find_hscp_outliers.R
@@ -1,0 +1,31 @@
+# Add some metrics to the lookup 
+lookup_with_metrics <- lookup |> 
+  mutate(
+    locality_length = str_width(hscp_locality),
+    hscp_length = str_width(hscp2019name)) |> 
+  group_by(hscp2019name) |> 
+  mutate(
+    n_localities = n_distinct(hscp_locality),
+    total_length = str_width(paste0(paste(hscp_locality, collapse = ""), hscp2019name))
+    ) |> 
+  ungroup()
+
+# Use the metrics to take the HSCP with:
+# The longest and shortest locality name
+# The most and least number of localities
+# The longest and shortest when considering all locality names + the HSCP name
+# The longest HSCP name
+# Note there will likely be overlaps, so the list shouldn't be too long
+outlier_hscps <- bind_rows(
+  slice_max(lookup_with_metrics, locality_length, with_ties = FALSE),
+  slice_max(lookup_with_metrics, n_localities, with_ties = FALSE),
+  slice_max(lookup_with_metrics, total_length, with_ties = FALSE),
+  slice_max(lookup_with_metrics, hscp_length, with_ties = FALSE),
+  slice_min(lookup_with_metrics, locality_length, with_ties = FALSE),
+  slice_min(lookup_with_metrics, n_localities, with_ties = FALSE),
+  slice_min(lookup_with_metrics, total_length, with_ties = FALSE),
+) |> 
+  pull(hscp2019name) |> 
+  unique()
+
+rm(lookup_with_metrics)


### PR DESCRIPTION
This adds some code that considers some metrics and comes up with a list of HSCPs to test that are most likely to cause issues.

This is to be used for a bigger test of the profiles, without having to run every single one.

The metrics it considers are:
 - The longest and shortest locality name
 -  The most and least number of localities
 -  The longest and shortest when considering all locality names + the HSCP name
 -  The longest HSCP name