### PR TITLE
Fix heading clipping on LTC types plot

### DIFF
--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -804,7 +804,7 @@ ltc_types_plot <- plot_grid(
   ),
   caption,
   nrow = 3,
-  rel_heights = c(0.1, 1, 0.1)
+  rel_heights = c(3, 20, 1)
 )
 
 

--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -240,7 +240,7 @@ avg_life_exp_latest_male <- ifelse(
   locality_missing,
   NA_real_,
   filter(
-    life_exp, 
+    life_exp,
     sex == "Male",
     year == latest_year_life_exp_loc,
     area_name == LOCALITY,
@@ -254,7 +254,7 @@ avg_life_exp_latest_fem <- ifelse(
   locality_missing,
   NA_real_,
   filter(
-    life_exp, 
+    life_exp,
     sex == "Female",
     year == latest_year_life_exp_loc,
     area_name == LOCALITY,

--- a/General Health/General-Health-Testing-Markdown.Rmd
+++ b/General Health/General-Health-Testing-Markdown.Rmd
@@ -156,7 +156,7 @@ Below is a breakdown of the physical LTCs, for the financial year `r latest_year
 
 #### Figure `r x`: The percentage of people with each physical LTC by age group. \newline
 
-```{r ltc_types_plot, echo = FALSE, fig.width = 7.5, fig.height = 3.8, fig.cap = "A graph showing the prevalence of physical long term conditions by percentage of population for Under 65s and for Over 65s."}
+```{r ltc_types_plot, echo = FALSE, fig.width = 7.5, fig.height = 5, fig.cap = "A graph showing the prevalence of physical long term conditions by percentage of population for Under 65s and for Over 65s."}
 ltc_types_plot
 
 x <- x + 1

--- a/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
+++ b/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
@@ -395,7 +395,7 @@ Below is a breakdown of the physical LTCs, for the financial year `r latest_year
 
 #### Figure `r x`: The percentage of people with each physical LTC by age group. \newline
 
-```{r ltc_types_plot, echo = FALSE, fig.width = 7.5, fig.height = 3.8, fig.cap = "A graph showing the prevalence of physical long term conditions by percentage of population for Under 65s and for Over 65s."}
+```{r ltc_types_plot, echo = FALSE, fig.width = 7.5, fig.height = 5, fig.cap = "A graph showing the prevalence of physical long term conditions by percentage of population for Under 65s and for Over 65s."}
 ltc_types_plot
 
 x <- x + 1


### PR DESCRIPTION
I increased the height of the figure in the final output, I also gave more space to the heading in the plot layout. This was mainly to fix the very long locality name in C&S.