### PR TITLE
Fix year typo in SIMD table

### DIFF
--- a/Demographics/Demographics-Testing-Markdown.Rmd
+++ b/Demographics/Demographics-Testing-Markdown.Rmd
@@ -127,7 +127,7 @@ Table `r y` details the percentage of the locality's 2016 population living in t
 knitr::kable(simd_diff_overall,
   col.names = c(
     "**Quintile**", "**Percent of 2016 Population (SIMD 2016 Ranking)**",
-    glue("**Percent of {pop_max_year} Population (SIMD 2020 Ranking)**"), 
+    glue("**Percent of {pop_max_year} Population (SIMD 2020 Ranking)**"),
     "**Difference**"
   ),
   align = c("l", "r", "r", "r"),

--- a/Demographics/Demographics-Testing-Markdown.Rmd
+++ b/Demographics/Demographics-Testing-Markdown.Rmd
@@ -8,12 +8,15 @@ output:
     df_print: paged
 ---
 
-
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(echo = TRUE)
 options(kableExtra.auto_format = FALSE)
 
-# Line below for testing only
+x <- 1 # object for figure numbers
+y <- 1 # object for table numbers
+```
+
+```{r testing_setup, include=FALSE}
 # LOCALITY <-  "Skye, Lochalsh and West Ross"
 # LOCALITY <- "Falkirk West"
 # LOCALITY <- "Stirling City with the Eastern Villages Bridge of Allan and Dunblane"
@@ -22,36 +25,45 @@ options(kableExtra.auto_format = FALSE)
 # LOCALITY <- "City of Dunfermline"
 LOCALITY <- "Inverness"
 
-source("Demographics/Scripts/1. Demographics - Population.R")
-source("Demographics/Scripts/2. Demographics - SIMD.R")
+# Source in functions code
+source("Master RMarkdown Document & Render Code/Global Script.R")
 
-x <- 1 # object for figure numbers
-y <- 1 # object for table numbers
+# Set file path
+lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 ```
 
-#####Page break
+```{r prepare_data_populations, include = FALSE}
+source("Demographics/1. Demographics - Population.R")
+```
+
+```{r prepare_data_simd, include = FALSE}
+source("Demographics/2. Demographics - SIMD.R")
+```
 
 ## Demographics
 
-### Summary:
-
 \newline
 
-**For the most recent time periods available, `r LOCALITY` Locality had:**
+**Summary**
 
-+ A total population of **`r total_population`** people, where **`r gender_breakdown[gender_breakdown$sex == "M",]$perc`** were male, and **`r over65`%** were aged over 65.
-+ **`r perc_top_quintile`%** of people lived in the least deprived SIMD quintile, and **`r perc_bottom_quintile`%** lived in the most deprived quintile.
+For the most recent time period available, `r LOCALITY` Locality had:
 
+-   A total population of **`r total_population`** people, where **`r gender_breakdown[gender_breakdown$sex == "M",]$perc`** were male, and **`r over65`%** were aged over 65.
+-   **`r perc_top_quintile`%** of people lived in the least deprived SIMD quintile, and **`r perc_bottom_quintile`%** lived in the most deprived quintile.
+
+\newline
 
 ### Population
+
 <!-- Total Population Text -->
+
 In `r pop_max_year`, the total population of `r LOCALITY` locality was `r total_population`. The graph below shows the population distribution of the locality. Overall, **`r gender_breakdown[gender_breakdown$sex == "M",]$perc`** of the population are male, and **`r gender_breakdown[gender_breakdown$sex == "F",]$perc`** are female.
 
-####Figure `r x`: Population by age and sex.
+#### Figure `r x`: Population by age and sex.
 
 \newline
 
-```{r echo = FALSE, fig.width = 6, fig.height = 3, warning = FALSE}
+```{r echo = FALSE, fig.width = 7, fig.height = 4, warning = FALSE, fig.cap = "A bar chart showing the population distribution of the locality grouped by age and sex"}
 pop_pyramid
 
 x <- x + 1
@@ -59,15 +71,15 @@ x <- x + 1
 
 <!-- Population over time -->
 
-Figure `r x` shows the historical population of `r LOCALITY`, along with the NRS population projections. `r pop_graph_text` `r pop_proj_text`. *Please see the footnotes for more information on how the population projections were calculated^1^.* 
+Figure `r x` shows the historical population of `r LOCALITY`, along with the NRS population projections. `r pop_graph_text` `r pop_proj_text`. *Please see the footnotes for more information on how the population projections were calculated^1^.*
 
+##### Page break
 
-#####Page break
+#### Figure `r x`: Population time trend and projection.
 
-####Figure `r x`: Population time trend and projection.
 \newline
 
-```{r echo = FALSE, fig.width = 7, fig.height = 3, warning = FALSE}
+```{r echo = FALSE, fig.width = 7.5, fig.height = 4, warning = FALSE, fig.cap= "A line graph showing the trend in population over time"}
 pop_ts_plot
 
 x <- x + 1
@@ -75,12 +87,13 @@ x <- x + 1
 
 \newline
 
-Figure `r x` shows how population structure has changed between `r pop_min_year` and `r pop_max_year`.
+Figure `r x` shows how the population structure has changed between `r pop_min_year` and `r pop_max_year`.
 
-####Figure `r x`: Change in population structure over the last five years.
+#### Figure `r x`: Change in population structure over the last five years.
+
 \newline
 
-```{r echo = FALSE, fig.width = 7, fig.height = 3.5, warning = FALSE}
+```{r echo = FALSE, fig.width = 9, fig.height = 4, warning = FALSE, fig.cap= "A bar chart showing the percentage change in population structure, split by age and sex, over the last five years"}
 hist_pop_change
 
 x <- x + 1
@@ -89,14 +102,14 @@ x <- x + 1
 ##### Page break
 
 ### Deprivation
-The following section explores the deprivation structure of `r LOCALITY` through the Scottish Index of Multiple Deprivation (SIMD). The SIMD ranks all datazones in Scotland by a number of factors; Access, Crime, Education, Employment, Health, Housing and Income. Based on these ranks, each datazone is then given an overall deprivation rank, which is used to split datazones into Deprivation Quintiles (Quintile 1 being the most deprived, and Quintile 5 the least). The most recent SIMD ranking was carried out in 2020. This section mainly focuses on the SIMD 2020 classifications, however the 2016 classifications are used to assess how deprivation has changed in `r LOCALITY` when compared to the rest of Scotland.
 
-Of the `r pop_max_year` population in `r LOCALITY`, **`r perc_bottom_quintile`%** live in the most deprived Quintile (SIMD 1), and **`r perc_top_quintile`%** live in the least deprived Quintile (SIMD 5). 
+The following section explores the deprivation structure of `r LOCALITY` through the Scottish Index of Multiple Deprivation (SIMD). The SIMD ranks all datazones in Scotland by a number of factors; Access, Crime, Education, Employment, Health, Housing and Income. Based on these ranks, each datazone is then given an overall deprivation rank, which is used to split datazones into Deprivation Quintiles (Quintile 1 being the most deprived, and Quintile 5 the least). The most recent SIMD ranking was carried out in 2020. This section mainly focuses on the SIMD 2020 classifications, however, the 2016 classifications are used to assess how deprivation has changed in `r LOCALITY` when compared to the rest of Scotland.
 
+Of the `r pop_max_year` population in `r LOCALITY`, **`r perc_bottom_quintile`%** live in the most deprived Quintile (SIMD 1), and **`r perc_top_quintile`%** live in the least deprived Quintile (SIMD 5).
 
-####Figure `r x`: Map of Data Zones within `r LOCALITY` coloured by SIMD  quintiles.
+#### Figure `r x`: Map of Data Zones within `r LOCALITY` coloured by SIMD quintiles.
 
-```{r echo = FALSE, fig.width = 7, warning = FALSE}
+```{r echo = FALSE, fig.width = 8, warning = FALSE, fig.cap = 'A map of the locality which is broken down by data zones with the colouring showing the SIMD quintile for each.'}
 simd_map
 
 x <- x + 1
@@ -104,46 +117,49 @@ x <- x + 1
 
 ##### Page break
 
-The following table details the percentage of the 2016 population living in the 2016 SIMD Quintiles, the percentage of the `r pop_max_year` population living in the 2020 SIMD Quintiles, and their difference for comparison. Figure `r x` then breaks down SIMD by domain in `r LOCALITY`.
+Table `r y` details the percentage of the locality's 2016 population living in the 2016 SIMD Quintiles, the percentage of the `r pop_max_year` population living in the 2020 SIMD Quintiles, and their difference for comparison. Figure `r x` then breaks down SIMD by domain in `r LOCALITY`.
 
-####Table `r y`: Percentage population living in the 2016 and 2020 SIMD Datazone Quintiles in 2016 and `r pop_max_year` respectively.
+#### Table `r y`: Percentage of the `r LOCALITY` population living in the 2016 and 2020 SIMD Datazone Quintiles in 2016 and `r pop_max_year` respectively.
+
 \newline
 
 ```{r echo = FALSE}
 knitr::kable(simd_diff_overall,
   col.names = c(
     "**Quintile**", "**Percent of 2016 Population (SIMD 2016 Ranking)**",
-    "**Percent of 2021 Population (SIMD 2020 Ranking)**", "**Difference**"
+    glue("**Percent of {pop_max_year} Population (SIMD 2020 Ranking)**"), 
+    "**Difference**"
   ),
-  align = c("l", "r", "r", "r")
+  align = c("l", "r", "r", "r"),
+  format = "markdown"
 )
 
 y <- y + 1
 ```
 
+Source: Scottish Government, Public Health Scotland, National Records Scotland. \newline
+
+#### Figure `r x`: Proportion of the population that reside in each 2020 SIMD quintile by domain in `r pop_max_year`.
+
 \newline
 
-####Figure `r x`: Proportion of the population that reside in each 2020 SIMD quintile by domain in `r pop_max_year`.
-\newline
-
-```{r echo = FALSE, fig.width = 7, fig.height = 4, warning = FALSE}
+```{r echo = FALSE, fig.width = 8, fig.height = 5, warning = FALSE, fig.cap = 'A bar graph showing the proportion of the population in each SIMD decile for each SIMD domain.'}
 simd_domains
 
 x <- x + 1
 ```
 
-
 ##### Page Break
 
-Figure `r x` presents a comparison between the 2016 SIMD ranking applied to 2016 population estimates, and the more recent 2020 SIMD ranking applied to `r pop_max_year` population estimates. The percentages of the population living within each SIMD quintile by domain were calculated using the 2016 and 2020 SIMD datazone classifications respectively. The differences in these percentages are plotted in Figure 6. Negative values on the y-axis indicate a decrease in percent of the population living within a quintile, while positive values indicate an increase in percent of the population living within a quintile. **Please note that quintiles have been weighted by the Scottish population so, any local changes in SIMD quintile do not necessarily indicate a difference in deprivation, but rather a difference in deprivation in comparison to the rest of Scotland.**
+Figure `r x` presents a comparison between the 2016 SIMD ranking applied to 2016 population estimates, and the more recent 2020 SIMD ranking applied to `r pop_max_year` population estimates. The percentages of the population living within each SIMD quintile by domain were calculated using the 2016 and 2020 SIMD datazone classifications respectively. The differences in these percentages are plotted in Figure `r x`. Negative values on the y-axis indicate a decrease in the percent of the population living within a quintile, while positive values indicate an increase in the percent of the population living within a quintile. **Please note that quintiles have been weighted by the Scottish population so, any local changes in SIMD quintile do not necessarily indicate a difference in deprivation, but rather a difference in deprivation in comparison to the rest of Scotland.**
 
 \newline
 
-####Figure `r x`: Percentage population in 2016 and `r pop_max_year` living in the 2016 and the 2020 SIMD quintiles by domain.
+#### Figure `r x`: Percentage of population in 2016 and `r pop_max_year` living in the 2016 and the 2020 SIMD quintiles by domain.
 
 \newline
 
-```{r echo = FALSE, fig.width = 7.5, fig.height = 7, warning = FALSE}
+```{r echo = FALSE, fig.width = 7.5, fig.height = 7, warning = FALSE, fig.cap = 'Bar graphs showing the percentage change of the population in each SIMD quintile by SIMD domain'}
 simd_diff_plot
 
 x <- x + 1

--- a/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
+++ b/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
@@ -127,7 +127,7 @@ Table `r y` details the percentage of the locality's 2016 population living in t
 knitr::kable(simd_diff_overall,
   col.names = c(
     "**Quintile**", "**Percent of 2016 Population (SIMD 2016 Ranking)**",
-    glue("**Percent of {pop_max_year} Population (SIMD 2020 Ranking)**"), 
+    glue("**Percent of {pop_max_year} Population (SIMD 2020 Ranking)**"),
     "**Difference**"
   ),
   align = c("l", "r", "r", "r"),

--- a/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
+++ b/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
@@ -127,7 +127,8 @@ Table `r y` details the percentage of the locality's 2016 population living in t
 knitr::kable(simd_diff_overall,
   col.names = c(
     "**Quintile**", "**Percent of 2016 Population (SIMD 2016 Ranking)**",
-    "**Percent of 2021 Population (SIMD 2020 Ranking)**", "**Difference**"
+    glue("**Percent of {pop_max_year} Population (SIMD 2020 Ranking)**"), 
+    "**Difference**"
   ),
   align = c("l", "r", "r", "r"),
   format = "markdown"


### PR DESCRIPTION
@CliveWG noted this issue in the Teams chat. The column header referred to 2021, not 2022. This is because it wasn't dynamic / hadn't been updated.

This change makes it dynamic.

The PR also updates the demographic testing markdown file to match the full one, so that it now works when you try to knit it.