### PR TITLE
Lifestyle and risk factors/fix text time trend

### DIFF
--- a/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
+++ b/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
@@ -94,7 +94,8 @@ min_year_drug_hosp <- min(drug_hosp[["year"]])
 latest_period_drug_hosp <- drug_hosp[["period_short"]][which.max(drug_hosp[["year"]])]
 earliest_period_drug_hosp <- drug_hosp[["period_short"]][which.min(drug_hosp[["year"]])]
 # ScotPHO time trend will only be latest 10 years
-earliest_period_drug_hosp_trend <- drug_hosp[["period_short"]][match(max_year_drug_hosp - 10, drug_hosp[["year"]])]
+trend_years <- 10
+earliest_period_drug_hosp_trend <- drug_hosp[["period_short"]][match(max_year_drug_hosp - trend_years, drug_hosp[["year"]])]
 
 
 ## Time trend
@@ -104,6 +105,7 @@ drug_hosp_time_trend <- drug_hosp %>%
     xaxis_title = "Financial Year Groups (3-year aggregates)",
     yaxis_title = "Drug-related admissions\n(Standardised rates per 100,000)",
     string_wrap = 10,
+    trend_years = trend_years,
     rotate_xaxis = TRUE
   )
 
@@ -129,7 +131,7 @@ drug_hosp_latest <- filter(
 drug_hosp_earliest <- filter(
   drug_hosp,
   year == min_year_drug_hosp,
-  area_name == LOCALITY, 
+  area_name == LOCALITY,
   area_type == "Locality"
 ) |> pull(measure)
 

--- a/Lifestyle & Risk Factors/Lifestyle-Risk-Factors-Testing-Markdown.Rmd
+++ b/Lifestyle & Risk Factors/Lifestyle-Risk-Factors-Testing-Markdown.Rmd
@@ -14,6 +14,11 @@ output:
 knitr::opts_chunk$set(echo = TRUE)
 options(kableExtra.auto_format = FALSE)
 
+x <- 1 # object for figure numbers
+y <- 1 # object for table numbers
+```
+
+```{r testing_setup, include = FALSE}
 # Line below for testing only
 # LOCALITY <- "Falkirk West"
 # LOCALITY <- "Stirling City with the Eastern Villages Bridge of Allan and Dunblane"
@@ -22,44 +27,39 @@ options(kableExtra.auto_format = FALSE)
 # LOCALITY <- "Skye, Lochalsh and West Ross"
 # LOCALITY <- "Ayr North and Former Coalfield Communities"
 
+source("Master RMarkdown Document & Render Code/Global Script.R")
 
-source("../Master RMarkdown Document & Render Code/Global Script.R")
-
-source("./2. Lifestyle & Risk Factors Outputs.R")
-
-
-x <- 1 # object for figure numbers
-y <- 1 # object for table numbers
+lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 ```
 
-##### Page break
+```{r produce_data, include = FALSE}
+source("Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R")
+```
 
 ## Lifestyle and Risk Factors
 
 \newline
 
-### Summary
+**Summary**
 
 Mental and physical well-being has close ties with people's lifestyles and behaviours. Financial security, employment and location are influences that often have a bearing on these choices. Issues can develop when alcohol, smoking or drug use shape lives. This section provides data on drug-related hospital admissions, alcohol-related hospital admissions, alcohol-specific deaths and bowel screening uptake, to give an overview of some of the lifestyles and behaviours for the `r LOCALITY` locality. These can give an idea of quality of life and prosperity.
 
-\newline
-
-**For the most recent time periods available^3^, `r LOCALITY` had:**
+For the most recent time period available^3^, `r LOCALITY` had:
 
 -   **`r format_number_for_text(alcohol_hosp_latest)`** alcohol-related hospital admissions per 100,000 age-sex standardised population. This is `r alcohol_hosp_diff_scot` than Scotland (`r  format_number_for_text(scot_alcohol_hosp)` admissions per 100,000)^4^.
 -   **`r format_number_for_text(alcohol_deaths_latest)`** alcohol-specific deaths per 100,000 age-sex standardised population. This is `r alcohol_deaths_diff_scot` than Scotland (`r  format_number_for_text(scot_alcohol_deaths)` deaths per 100,000)^4^.
 -   **`r format_number_for_text(drug_hosp_latest)`** drug-related hospital admissions per 100,000 age-sex standardised population. This is `r drug_hosp_diff_scot` than Scotland (`r format_number_for_text(scot_drug_hosp)` admissions per 100,000)^4^.
--   **`r format_number_for_text(bowel_screening_latest)`%** uptake of bowel screening among eligible population, compared to `r format_number_for_text(scot_bowel_screening)`% in Scotland.
+-   **`r format_number_for_text(bowel_screening_latest)`%** uptake of bowel screening among the eligible population, compared to `r format_number_for_text(scot_bowel_screening)`% in Scotland.
 
 \newline
 
-###Alcohol-related Hospital Admissions
+### Alcohol-related Hospital Admissions
 
 In `r latest_period_alcohol_hosp`, the rate of alcohol-related admissions was **`r format_number_for_text(alcohol_hosp_latest)`** per 100,000 age-sex standardised population in `r LOCALITY`. This is `r get_article(alcohol_hosp_change)` `r format_number_for_text(alcohol_hosp_change)`% `r alcohol_hosp_change_word` overall since `r earliest_period_alcohol_hosp`. Figure `r x` shows a trend of alcohol-related hospital admissions for `r LOCALITY` locality compared with Scotland, `r HSCP` HSCP and `r HB` from financial year `r earliest_period_alcohol_hosp` to `r latest_period_alcohol_hosp`.
 
 Figure `r x + 1` then compares different areas, including the other localities in `r HSCP`, for the latest financial year. This bar chart shows that in `r latest_period_alcohol_hosp`, `r LOCALITY` locality had a `r alcohol_hosp_diff_scot` alcohol-related hospital admissions rate compared to Scotland (`r format_number_for_text(alcohol_hosp_latest)` and `r  format_number_for_text(scot_alcohol_hosp)` admissions respectively).
 
-#####Page break
+##### Page break
 
 #### Figure `r x`: Alcohol-related hospital admission rates by area and over time.
 
@@ -83,7 +83,7 @@ x <- x + 1
 
 \newline
 
-###Alcohol-Specific Deaths
+### Alcohol-Specific Deaths
 
 Data on alcohol-specific deaths is available as 5-year aggregates. In `r LOCALITY`, the latest rate of alcohol-specific deaths was **`r format_number_for_text(alcohol_deaths_latest)`** deaths per 100,000 age-sex standardised population. This is `r format_number_for_text(alcohol_deaths_change)`% `r alcohol_deaths_change_word` than the rate in `r earliest_period_alcohol_deaths`. Figure `r x + 1` also shows that the locality has a `r alcohol_deaths_diff_scot` alcohol-specific death rate compared to Scotland overall (`r  format_number_for_text(scot_alcohol_deaths)` deaths per 100,000).
 
@@ -125,7 +125,7 @@ drug_hosp_time_trend
 x <- x + 1
 ```
 
-#####Page break
+##### Page break
 
 #### Figure `r x`: Drug-related hospital admission rates by area for the latest time period available.
 
@@ -137,11 +137,11 @@ x <- x + 1
 
 \newline
 
-###Bowel Screening Uptake
+### Bowel Screening Uptake
 
 Bowel screening is offered every two years to eligible men and women aged between 50-74 years old. Eligible people are posted a test kit which is completed at home. Since 1st April 2013, those aged 75 and over can also self-refer and opt into screening.
 
-A trend of the percentage uptake of bowel screening among the eligible population is shown the locality and comparable areas. Data is suppressed into 3-year aggregates. The `r latest_period_bowel_screening` uptake rate for `r LOCALITY` is **`r format_number_for_text(bowel_screening_latest)`%**. This is `r get_article(bowel_screening_change)` `r format_number_for_text(bowel_screening_change)`% `r bowel_screening_change_word` since `r earliest_period_bowel_screening`. As can be seen in figure `r x + 1`, in the latest estimate, the uptake in `r LOCALITY` was `r bowel_screening_diff_scot` than the uptake in Scotland overall (`r format_number_for_text(scot_bowel_screening)`%).
+A trend of the percentage uptake of bowel screening among the eligible population is shown for `r LOCALITY` and comparable areas. Data is presented as 3-year aggregates. The `r latest_period_bowel_screening` uptake rate for `r LOCALITY` is **`r format_number_for_text(bowel_screening_latest)`%**. This is `r get_article(bowel_screening_change)` `r format_number_for_text(bowel_screening_change)`% `r bowel_screening_change_word` since `r earliest_period_bowel_screening`. As can be seen in Figure `r x + 1`, in the latest estimate, the uptake in `r LOCALITY` was `r bowel_screening_diff_scot` than the uptake in Scotland overall (`r format_number_for_text(scot_bowel_screening)`%).
 
 ##### Page break
 

--- a/Lifestyle & Risk Factors/Lifestyle-Risk-Factors-Testing-Markdown.Rmd
+++ b/Lifestyle & Risk Factors/Lifestyle-Risk-Factors-Testing-Markdown.Rmd
@@ -109,11 +109,11 @@ x <- x + 1
 
 \newline
 
-###Drug-related Hospital Admissions
+### Drug-related Hospital Admissions
 
-There were **`r format_number_for_text(drug_hosp_latest)`** drug-related hospital admissions per 100,000 age-sex standardised population^4^ in the `r LOCALITY` locality in the time period `r latest_period_drug_hosp` (3-year financial year aggregate). This is `r get_article(drug_hosp_change)` `r format_number_for_text(drug_hosp_change)`% `r drug_hosp_change_word` since `r earliest_period_drug_hosp`. A trend of the change in drug-related hospital admissions for the locality and comparable areas is shown in figure `r x` from `r earliest_period_drug_hosp` onward.
+There were **`r format_number_for_text(drug_hosp_latest)`** drug-related hospital admissions per 100,000 age-sex standardised population^4^ in the `r LOCALITY` locality in the time period `r latest_period_drug_hosp` (3-year financial year aggregate). This is `r get_article(drug_hosp_change)` `r format_number_for_text(drug_hosp_change)`% `r drug_hosp_change_word` since `r earliest_period_drug_hosp`. A trend of the change in drug-related hospital admissions for the locality and comparable areas is shown in Figure `r x` from `r earliest_period_drug_hosp_trend` onward.
 
-A comparison of areas at the most recent time period (`r latest_period_drug_hosp` aggregated financial years) is available in figure `r x + 1` This shows the `r LOCALITY` locality has a `r drug_hosp_diff_scot` rate of drug-related hospital admissions than Scotland (`r format_number_for_text(scot_drug_hosp)` admissions per 100,000).
+A comparison of areas at the most recent time period (`r latest_period_drug_hosp` aggregated financial years) is available in Figure `r x + 1` This shows the `r LOCALITY` locality has a `r drug_hosp_diff_scot` rate of drug-related hospital admissions than Scotland (`r format_number_for_text(scot_drug_hosp)` admissions per 100,000).
 
 #### Figure `r x`: Drug-related hospital admission rates by area and over time.
 

--- a/Master RMarkdown Document & Render Code/Global Script.R
+++ b/Master RMarkdown Document & Render Code/Global Script.R
@@ -273,7 +273,7 @@ clean_scotpho_dat <- function(data) {
 # (ScotPHO data uses year aggregates which don't always fit on axis unless wrapped)
 # rotate_xaxis: default F, if labels still don't fit even with wrapping (prev argument), labels can be rotated
 
-scotpho_time_trend <- function(data, chart_title, xaxis_title, yaxis_title, string_wrap, rotate_xaxis = FALSE) {
+scotpho_time_trend <- function(data, chart_title, xaxis_title, yaxis_title, string_wrap, rotate_xaxis = FALSE, trend_years = 10) {
   # rotate axis criteria if T/F
   if (rotate_xaxis) {
     rotation <- element_text(angle = 45, hjust = 1)
@@ -287,7 +287,7 @@ scotpho_time_trend <- function(data, chart_title, xaxis_title, yaxis_title, stri
       (area_name == HSCP & area_type == "HSCP") |
       area_name == HB |
       area_name == "Scotland") %>%
-    filter(year >= max(year) - 10) %>%
+    filter(year >= max(year) - trend_years) %>%
     mutate(
       area_type = factor(area_type, levels = c("Locality", "HSCP", "Health board", "Scotland")),
       area_name = fct_reorder(as.factor(str_wrap(area_name, 23)), as.numeric(area_type))

--- a/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
+++ b/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
@@ -553,7 +553,7 @@ x <- x + 1
 
 ### Drug-related Hospital Admissions
 
-There were **`r format_number_for_text(drug_hosp_latest)`** drug-related hospital admissions per 100,000 age-sex standardised population^4^ in the `r LOCALITY` locality in the time period `r latest_period_drug_hosp` (3-year financial year aggregate). This is `r get_article(drug_hosp_change)` `r format_number_for_text(drug_hosp_change)`% `r drug_hosp_change_word` since `r earliest_period_drug_hosp`. A trend of the change in drug-related hospital admissions for the locality and comparable areas is shown in Figure `r x` from `r earliest_period_drug_hosp` onward.
+There were **`r format_number_for_text(drug_hosp_latest)`** drug-related hospital admissions per 100,000 age-sex standardised population^4^ in the `r LOCALITY` locality in the time period `r latest_period_drug_hosp` (3-year financial year aggregate). This is `r get_article(drug_hosp_change)` `r format_number_for_text(drug_hosp_change)`% `r drug_hosp_change_word` since `r earliest_period_drug_hosp`. A trend of the change in drug-related hospital admissions for the locality and comparable areas is shown in Figure `r x` from `r earliest_period_drug_hosp_trend` onward.
 
 A comparison of areas at the most recent time period (`r latest_period_drug_hosp` aggregated financial years) is available in Figure `r x + 1` This shows the `r LOCALITY` locality has a `r drug_hosp_diff_scot` rate of drug-related hospital admissions than Scotland (`r format_number_for_text(scot_drug_hosp)` admissions per 100,000).
 


### PR DESCRIPTION
The key change here is creating the new variable `earliest_period_drug_hosp_trend` and using this in the text.

I updated some code around that point as I thought I could do it differently to what ended up being the final result.

None of the package loads were required (all loaded in General).

I made the L&RF markdown match the 'full' markdown, so now it knits properly.