### PR TITLE
Add a workflow to run lintr

### DIFF
--- a/.github/workflows/lint-modified-files.yaml
+++ b/.github/workflows/lint-modified-files.yaml
@@ -10,7 +10,7 @@ name: lint-modified-files.yaml
 permissions: read-all
 
 jobs:
-  lint-project:
+  lint-modified-files:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-modified-files.yaml
+++ b/.github/workflows/lint-modified-files.yaml
@@ -21,8 +21,12 @@ jobs:
         with:
           use-public-rspm: true
 
-      - name: Install lintr and lifecyle
-        run: install.packages(c("lintr", "lifecycle"))
+      - name: Install pak (will install any system dependencies too)
+        run: install.packages("pak")
+        shell: Rscript {0}
+
+      - name: Install styler and other packages
+        run: pak::pkg_install(pkg = c("lintr", "lifecycle", "purrr", "gh"), dependencies = TRUE)
         shell: Rscript {0}
 
       - name: Extract and lint files changed by this PR
@@ -30,7 +34,7 @@ jobs:
           files <- gh::gh("GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
           changed_files <- purrr::map_chr(files, "filename")
           all_files <- list.files(recursive = TRUE)
-          exclusions_list <- as.list(setdiff(all_files, changed_files))
+          exclusions <- setdiff(all_files, changed_files)
           lintr::lint_dir(exclusions = exclusions_list)
         shell: Rscript {0}
         env:

--- a/.github/workflows/lint-modified-files.yaml
+++ b/.github/workflows/lint-modified-files.yaml
@@ -1,0 +1,37 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: lint-modified-files.yaml
+
+permissions: read-all
+
+jobs:
+  lint-project:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install lintr and lifecyle
+        run: install.packages(c("lintr", "lifecycle"))
+        shell: Rscript {0}
+
+      - name: Extract and lint files changed by this PR
+        run: |
+          files <- gh::gh("GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          changed_files <- purrr::map_chr(files, "filename")
+          all_files <- list.files(recursive = TRUE)
+          exclusions_list <- as.list(setdiff(all_files, changed_files))
+          lintr::lint_dir(exclusions = exclusions_list)
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: false

--- a/.github/workflows/lint-modified-files.yaml
+++ b/.github/workflows/lint-modified-files.yaml
@@ -38,7 +38,7 @@ jobs:
           changed_files <- purrr::map_chr(files, "filename")
           all_files <- list.files(recursive = TRUE)
           exclusions <- setdiff(all_files, changed_files)
-          lintr::lint_dir(exclusions = exclusions_list)
+          lintr::lint_dir(exclusions = exclusions)
         shell: Rscript {0}
         env:
           LINTR_ERROR_ON_LINT: false

--- a/.github/workflows/lint-modified-files.yaml
+++ b/.github/workflows/lint-modified-files.yaml
@@ -21,6 +21,9 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: Remove the .Rprofile (if present)
+        run: if [ -f .Rprofile ]; then rm .Rprofile; fi
+
       - name: Install pak (will install any system dependencies too)
         run: install.packages("pak")
         shell: Rscript {0}

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,10 @@
+linters: all_linters(
+  packages = c("lintr", "lifecycle"),
+  undesirable_function_linter = NULL,
+  object_name_linter = object_name_linter(styles = "snake_case"),
+  absolute_path_linter = NULL,
+  object_usage_linter = NULL,
+  pipe_consistency_linter = pipe_consistency_linter(pipe = "|>")
+  ) # see vignette("lintr")
+encoding: "UTF-8"
+exclusions: list("renv", "packrat") # see ?lintr::exclude


### PR DESCRIPTION
This will run on every pull request (PR) and highlight any linting suggestions. Initially, there may be quite a few issues, but hopefully, we can resolve many of them and improve the code to meet best practices!

The `.lintr` file configures the options. I've set some options for specific linters while indicating that others should be ignored (`... = NULL`). We can modify this as needed.