### PR TITLE
Fix USC summary table when data is missing 

### DIFF
--- a/Summary Table/Summary-Table-Markdown.Rmd
+++ b/Summary Table/Summary-Table-Markdown.Rmd
@@ -296,13 +296,23 @@ datatype <- c("rate", "rate")
 time <- c(str_wrap(latest_period_psych_hosp, 9), max_fy)
 
 # Values
-loc_values <- c(psych_hosp_latest, latest_bed_days_mh_loc$data) |>
-  format(big.mark = ",")
+loc_values <- c(
+  format(psych_hosp_latest, big.mark = ","),
+  format(
+    ifelse(is_empty(latest_bed_days_mh_loc$data), NA_real_, latest_bed_days_mh_loc$data),
+    big.mark = ","
+  )
+)
 other_loc_values <- bind_rows(other_locs_psych_hosp, other_loc_bed_days_mh)
-hscp_values <- c(filter(hscp_psych_hosp, year == max(year))$measure, hscp_bed_days_mh$data) |>
-  format(big.mark = ",")
-scot_values <- c(filter(scot_psych_hosp, year == max(year))$measure, scot_bed_days_mh$data) |>
-  format(big.mark = ",")
+hscp_values <- c(
+  format(filter(hscp_psych_hosp, year == max(year))$measure, big.mark = ","),
+  format(hscp_bed_days_mh$data, big.mark = ",")
+)
+scot_values <- c(
+  format(filter(scot_psych_hosp, year == max(year))$measure, big.mark = ","),
+  format(scot_bed_days_mh$data, big.mark = ",")
+)
+
 
 usc_mh_values <- tibble(
   indicators, datatype, time, loc_values, other_loc_values,

--- a/Summary Table/Summary-Table-Markdown.Rmd
+++ b/Summary Table/Summary-Table-Markdown.Rmd
@@ -83,9 +83,12 @@ make_summary_table <- function(data) {
   scot_col <- ncol(data)
 
   data |>
-    # Remove odd spaces in numbers
     mutate(
-      across(all_of(c(loc_col, other_loc_cols, hscp_col, scot_col)), str_squish)
+      # Remove odd spaces in numbers
+      across(all_of(c(loc_col, other_loc_cols, hscp_col, scot_col)), str_squish),
+      # Make any missing values a dash
+      across(all_of(c(loc_col, other_loc_cols, hscp_col, scot_col)), \(x) na_if(x, "NA")),
+      across(all_of(c(loc_col, other_loc_cols, hscp_col, scot_col)), \(x) replace_na(x, "-")),
     ) |>
     flextable() |>
     # Header


### PR DESCRIPTION
This previously duplicated the data when one of the values was there but the other wasn't. This will now force an NA.

In particular, see the Orkney locality "Isles"—there was no data for `Unscheduled bed days per 100,000`, but there was a value for `Psychiatric patient hospitalisations per 100,000`, and this was just being repeated, which is not correct.