### PR TITLE
Update .lintr

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,7 @@
 linters: all_linters(
   absolute_path_linter = NULL,
   commented_code_linter = NULL,
+  line_length_linter = line_length_linter(length = 100L)
   missing_package_linter = NULL,
   object_name_linter = object_name_linter(styles = "snake_case"),
   object_usage_linter = NULL,


### PR DESCRIPTION
Make the line_length_linter less strict, so it will only highlight lines over 100 characters instead of the 80 it does at the moment