### PR TITLE
Remove dplyr explicit function calls (`dplyr::fun()`)

### DIFF
--- a/Demographics/1. Demographics - Population.R
+++ b/Demographics/1. Demographics - Population.R
@@ -120,7 +120,7 @@ pop_breakdown <- pops %>%
       gsub("Pop", "", variable)
     )
   )) %>%
-  dplyr::rename(Gender = sex, Age = variable, Population = value) %>%
+  rename(Gender = sex, Age = variable, Population = value) %>%
   mutate(Gender = case_when(
     Gender == "M" ~ "Male",
     Gender == "F" ~ "Female"
@@ -171,10 +171,10 @@ hist_pop_breakdown <- pops %>%
       gsub("Pop", "", variable)
     )
   )) %>%
-  dplyr::rename(Gender = sex, Age = variable, Population = value) %>%
-  dplyr::group_by(Gender, Age) %>%
+  rename(Gender = sex, Age = variable, Population = value) %>%
+  group_by(Gender, Age) %>%
   arrange(year) %>%
-  dplyr::summarise(change = (last(Population) - first(Population)) / first(Population)) %>%
+  summarise(change = (last(Population) - first(Population)) / first(Population)) %>%
   ungroup() %>%
   mutate(Gender = ifelse(Gender == "F", "Female", "Male"))
 
@@ -211,7 +211,7 @@ hist_pop_change <- ggplot(
 locality_pop_trend <- pops %>%
   filter(hscp_locality == LOCALITY) %>%
   group_by(year) %>%
-  dplyr::summarise(pop = sum(total_pop)) %>%
+  summarise(pop = sum(total_pop)) %>%
   ungroup()
 
 ## Population projections by locality
@@ -222,7 +222,7 @@ loc_pops <- pops %>%
   filter(year == pop_max_year) %>%
   filter(!(hscp_locality %in% c("Partnership Total", "Scotland Total"))) %>%
   reshape2::melt(id.vars = c("year", "sex", "hscp2019name", "hscp_locality")) %>%
-  dplyr::rename(age_group = variable) %>%
+  rename(age_group = variable) %>%
   as_tibble() %>%
   select(-year)
 
@@ -241,7 +241,7 @@ hscp_pop_proj_weight <- hscp_pop_proj %>%
   filter(year %in% pop_max_year:2028) %>%
   # aggregate to age groups
   group_by(year, hscp2019, hscp2019name, sex, age_group) %>%
-  dplyr::summarise(pop = sum(pop)) %>%
+  summarise(pop = sum(pop)) %>%
   ungroup() %>%
   # change sex variable coding
   mutate(sex = ifelse(sex == 1, "M", "F")) %>%
@@ -268,7 +268,7 @@ locality_pop_proj <- hscp_pop_proj_weight %>%
 pop_proj_dat <- locality_pop_proj %>%
   filter(hscp_locality == LOCALITY) %>%
   group_by(year) %>%
-  dplyr::summarise(pop = sum(pop)) %>%
+  summarise(pop = sum(pop)) %>%
   ungroup()
 
 

--- a/Demographics/2. Demographics - SIMD.R
+++ b/Demographics/2. Demographics - SIMD.R
@@ -223,7 +223,7 @@ simd_domains <- simd2020 %>%
   select(income, employment, education, access, crime, health, housing, total_pop) %>%
   reshape2::melt(id.vars = "total_pop") %>%
   group_by(variable, value) %>%
-  dplyr::summarise(total_pop = sum(total_pop)) %>%
+  summarise(total_pop = sum(total_pop)) %>%
   ggplot(aes(
     fill = factor(value, levels = 1:5), y = total_pop,
     x = factor(variable, levels = tolower(plot_labels))
@@ -265,8 +265,8 @@ names(simd2016_dom)[2:9] <- paste0(names(simd2016_dom)[2:9], "_16")
 pop_16_20 <- pop_raw_data %>%
   filter(year %in% c(2016, pop_max_year)) %>%
   select(year, datazone2011, sex, pop = total_pop) %>%
-  dplyr::group_by(datazone2011, year) %>%
-  dplyr::summarise(pop = sum(pop)) %>%
+  group_by(datazone2011, year) %>%
+  summarise(pop = sum(pop)) %>%
   ungroup() %>%
   mutate(simd_rank_year = if_else(year == 2016, "pop_16", "pop_20")) %>%
   select(-year) %>%
@@ -277,37 +277,37 @@ simd2016_dom <- simd2016_dom %>%
   left_join(pop_16_20, by = join_by(datazone2011)) %>%
   select(datazone2011, contains("_16")) %>%
   reshape2::melt(id.vars = c("datazone2011", "pop_16")) %>%
-  dplyr::group_by(variable) %>%
-  dplyr::mutate(total_pop = sum(pop_16)) %>%
-  dplyr::group_by(variable, value) %>%
-  dplyr::summarise(
+  group_by(variable) %>%
+  mutate(total_pop = sum(pop_16)) %>%
+  group_by(variable, value) %>%
+  summarise(
     pop = sum(pop_16),
     total_pop = max(total_pop)
   ) %>%
-  dplyr::mutate(
+  mutate(
     perc_16 = pop / total_pop,
     domain = gsub("_16", "", variable)
   ) %>%
-  dplyr::ungroup() %>%
-  dplyr::select(domain, perc_16, quintile = value)
+  ungroup() %>%
+  select(domain, perc_16, quintile = value)
 
 simd2020_dom <- simd2020_dom %>%
   left_join(pop_16_20, by = join_by(datazone2011)) %>%
   select(datazone2011, contains("_20")) %>%
   reshape2::melt(id.vars = c("datazone2011", "pop_20")) %>%
-  dplyr::group_by(variable) %>%
-  dplyr::mutate(total_pop = sum(pop_20)) %>%
-  dplyr::group_by(variable, value) %>%
-  dplyr::summarise(
+  group_by(variable) %>%
+  mutate(total_pop = sum(pop_20)) %>%
+  group_by(variable, value) %>%
+  summarise(
     pop = sum(pop_20),
     total_pop = max(total_pop)
   ) %>%
-  dplyr::mutate(
+  mutate(
     perc_20 = pop / total_pop,
     domain = gsub("_20", "", variable)
   ) %>%
-  dplyr::ungroup() %>%
-  dplyr::select(domain, perc_20, quintile = value)
+  ungroup() %>%
+  select(domain, perc_20, quintile = value)
 
 domains <- simd2020_dom$domain %>% unique()
 base_data <- tibble(

--- a/Households/Households Code.R
+++ b/Households/Households Code.R
@@ -66,7 +66,7 @@ rm(temp)
 
 # Global Script Function to read in Localities Lookup
 lookup <- read_in_localities(dz_level = TRUE) %>%
-  dplyr::select(datazone2011, hscp_locality) %>%
+  select(datazone2011, hscp_locality) %>%
   filter(hscp_locality == LOCALITY)
 
 
@@ -75,8 +75,8 @@ house_dat <- house_raw_dat %>% filter(data_zone_code %in% lookup$datazone2011)
 
 # aggregate data
 house_dat1 <- house_dat %>%
-  dplyr::group_by(year) %>%
-  dplyr::summarise(
+  group_by(year) %>%
+  summarise(
     total_dwellings = sum(total_number_of_dwellings),
     occupied_dwellings = sum(occupied_dwellings),
     vacant_dwellings = sum(vacant_dwellings),
@@ -84,8 +84,8 @@ house_dat1 <- house_dat %>%
     tax_exempt = sum(occupied_dwellings_exempt_from_paying_council_tax),
     tax_discount = sum(dwellings_with_a_single_adult_council_tax_discount)
   ) %>%
-  dplyr::ungroup() %>%
-  dplyr::mutate(dplyr::across(3:7, list(perc = ~ 100 * .x / total_dwellings)))
+  ungroup() %>%
+  mutate(across(3:7, list(perc = ~ 100 * .x / total_dwellings)))
 
 
 ## 2b) Text objects ----
@@ -243,7 +243,7 @@ rm(lookup2)
 # Global Script Function to read in Localities Lookup
 other_locs_dz <- read_in_localities(dz_level = TRUE) %>%
   arrange() %>%
-  dplyr::select(datazone2011, hscp_locality) %>%
+  select(datazone2011, hscp_locality) %>%
   inner_join(other_locs, by = c("hscp_locality" = "hscp_locality"))
 
 house_dat_otherlocs <- house_raw_dat %>%
@@ -254,7 +254,7 @@ house_dat_otherlocs <- house_raw_dat %>%
     total_dwellings = sum(total_number_of_dwellings),
     tax_discount = sum(dwellings_with_a_single_adult_council_tax_discount)
   ) %>%
-  dplyr::ungroup() %>%
+  ungroup() %>%
   mutate(tax_discount_perc = round_half_up(tax_discount / total_dwellings * 100, 1))
 
 other_locs_n_houses <- house_dat_otherlocs %>%

--- a/Master RMarkdown Document & Render Code/Global Script.R
+++ b/Master RMarkdown Document & Render Code/Global Script.R
@@ -20,6 +20,8 @@ library(glue)
 library(fs)
 library(arrow)
 
+# Prefer dplyr functions if there's a conflict
+conflicted::conflict_prefer_all("dplyr", quiet = TRUE)
 
 #### Colours & Formatting #### ----
 


### PR DESCRIPTION
These should not be required as we load `{dplyr}` in global and now we've reduced the number of overall package loads it's much less likely that there will be function conflicts.