### PR TITLE
Suppress the messages about `.groups` from `dplyr::summarise`

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -35,3 +35,7 @@ options(readr.show_col_types = FALSE)
 
 # ggrepel options ----
 options("ggrepel.max.overlaps" = 12)
+
+# dplyr options ----
+# Suppresses the message about using `.groups`
+options("dplyr.summarise.inform" = FALSE)


### PR DESCRIPTION
This sets an option which causes the message about `.groups` to not be displayed. See: https://dplyr.tidyverse.org/reference/summarise.html#arguments

Whist `.groups` is a nice addition it's still labelled as 'experimental', as well as that, all of our code has been written without it and instead uses `ungroup()`. If `ungroup()` is ever deprecated or superseded, or possibly if `.groups` becomes stable, we should revisit this fix.