### PR TITLE
Use phsstyles instead of hardcoding the colours

### DIFF
--- a/Services/3. Service HSCP map.R
+++ b/Services/3. Service HSCP map.R
@@ -50,19 +50,11 @@ shp_hscp <- shp |>
 # 3.1 Palettes ----
 
 # Create colour palettes for different numbers of localities
-if (n_loc < 5) {
-  col_palette <- c("#3F3685", "#9B4393", "#0078D4", "#83BB26")
-} else if (n_loc %in% c(5, 6)) {
-  col_palette <- c("#3F3685", "#9B4393", "#0078D4", "#83BB26", "#948DA3", "#1E7F84")
-} else if (n_loc == 7) {
-  col_palette <- c("#3F3685", "#9B4393", "#0078D4", "#83BB26", "#948DA3", "#1E7F84", "#6B5C85")
-} else if (n_loc == 8) {
-  col_palette <- c("#3F3685", "#9B4393", "#0078D4", "#83BB26", "#948DA3", "#1E7F84", "#6B5C85", "#C73918")
-} else if (n_loc == 9) {
-  col_palette <- c("#3F3685", "#9B4393", "#0078D4", "#83BB26", "#948DA3", "#1E7F84", "#6B5C85", "#C73918", "orchid3")
-}
+# Take the colours from the PHS palette (8 main colours)
+col_palette <- phs_colors() |>
+  head(n_loc) # Take the first n_loc colours
 
-# 3.2 Loaclity shapes ----
+# 3.2 Locality shapes ----
 # Get latitude and longitude co-ordinates for each data locality, find min and max.
 zones_coord <- shp_hscp |>
   st_coordinates() |>


### PR DESCRIPTION
This will take the first `n_loc` colours from the PHS palette, which looks like this:

```
     phs-purple     phs-magenta        phs-blue       phs-green    phs-graphite 
      "#3F3685"       "#9B4393"       "#0078D4"       "#83BB26"       "#948DA3" 
       phs-teal     phs-liberty        phs-rust   phs-purple-80   phs-purple-50 
      "#1E7F84"       "#6B5C85"       "#C73918"       "#655E9D"       "#9F9BC2" 
  phs-purple-30   phs-purple-10  phs-magenta-80  phs-magenta-50  phs-magenta-30 
      "#C5C3DA"       "#ECEBF3"       "#AF69A9"       "#CDA1C9"       "#E1C7DF" 
 phs-magenta-10     phs-blue-80     phs-blue-50     phs-blue-30     phs-blue-10 
      "#F5ECF4"       "#3393DD"       "#80BCEA"       "#B3D7F2"       "#E6F2FB" 
   phs-green-80    phs-green-50    phs-green-30    phs-green-10 phs-graphite-80 
      "#9CC951"       "#C1DD93"       "#DAEBBE"       "#F3F8E9"       "#A9A4B5" 
phs-graphite-50 phs-graphite-30 phs-graphite-10     phs-teal-80     phs-teal-50 
      "#CAC6D1"       "#DFDDE3"       "#F4F4F6"       "#4B999D"       "#8FBFC2" 
    phs-teal-30     phs-teal-10  phs-liberty-80  phs-liberty-50  phs-liberty-30 
      "#BCD9DA"       "#E9F2F3"       "#897D9D"       "#B5AEC2"       "#D3CEDA" 
 phs-liberty-10     phs-rust-80     phs-rust-50     phs-rust-30     phs-rust-10 
      "#F0EFF3"       "#D26146"       "#E39C8C"       "#EEC4BA"       "#F9EBE8" 
```

There are only 8 'main' colours, the previous code went up to 9 and chose `orchid3` in the case where a 9th colour was needed. The new code will now choose `phs-purple-80`, I'm not sure which HSCP this will affect but we should check any with 9(+) localities and make sure the new colour choice is ok.

![image](https://github.com/user-attachments/assets/9bfdaf81-4e2e-425d-b861-cd2ecac381f8)
