### PR TITLE
Fix the path to the docx template

### DIFF
--- a/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
+++ b/Master RMarkdown Document & Render Code/Locality_Profiles_Master_Markdown.Rmd
@@ -3,8 +3,7 @@ title: ''
 output:
   word_document:
     fig_caption: false
-    reference_docx: //conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality
-      Profiles/Master RMarkdown Document & Render Code/Locality_Profiles_Report_Template.docx
+    reference_docx: "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/Master RMarkdown Document & Render Code/Locality_Profiles_Report_Template.docx"
   html_document:
     fig_caption: false
     df_print: paged


### PR DESCRIPTION
This used to work fine, but gives this error on the new workbench:

```
Could not fetch http://conf/LIST_analytics/West%20Hub/02%20-%20Scaled%20Up%20Work/RMarkdown/Locality%20Profiles/Master%20RMarkdown%20Document%20&%20Render%20Code/Locality_Profiles_Report_Template.docx
InvalidUrlException "proxy.nss.scot.nhs.uk:3128" "Invalid scheme"
```

Replacing the leading `//` with `/` resolved the issue.

The quotes aren't necessary, but I like them