### PR TITLE
Tweak the `stopifnot` check - suggested by `{lintr}`

### DIFF
--- a/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
+++ b/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
@@ -26,7 +26,7 @@ lookup <- read_in_localities()
 hscp_list <- "Angus"
 
 # NOTE - This checks that it exactly matches the lookup
-stopifnot(all(hscp_list %in% unique(lookup[["hscp2019name"]])))
+stopifnot(hscp_list %in% unique(lookup[["hscp2019name"]]))
 
 # Loop over HSCP ----
 # 'looping' over one HSCP is fine.


### PR DESCRIPTION
I noticed this lint suggested in #217 and applied it as it's very simple. The lint text was:

```
file=Master RMarkdown Document & Render Code/Locality Profiles Render Code.R,line=29,col=11,[stopifnot_all_linter] Use stopifnot(x) instead of stopifnot(all(x)). stopifnot(x) runs all() 'under the hood' and provides a better error message in case of failure.
```