### PR TITLE
Fix Figure 11 (General Health / Life expectancy)

### DIFF
--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -184,6 +184,7 @@ life_exp_trend <- life_exp %>%
   geom_point(size = 2) +
   scale_colour_manual(values = palette) +
   theme_profiles() +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
   expand_limits(y = 0) +
   labs(
     title = str_wrap(glue("Average Life Expectancy in {LOCALITY} locality"), width = 65),

--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -169,7 +169,7 @@ life_exp_trend <- life_exp %>%
     year >= max(year) - 10
   ) %>%
   mutate(
-    period_short = str_wrap(period_short, width = 10),
+    period_short = period_short,
     measure = round_half_up(measure, 1)
   ) %>%
   ggplot(aes(


### PR DESCRIPTION
The axis text was overlapping:

![image](https://github.com/user-attachments/assets/0207815d-2388-4b97-9289-489089f1df78)

This resolves it:

![image](https://github.com/user-attachments/assets/1b97b0bf-c366-475c-860e-b3ba5e745b0d)
