### PR TITLE
Comment out assignments of `HSCP` in scripts

### DIFF
--- a/Demographics/1. Demographics - Population.R
+++ b/Demographics/1. Demographics - Population.R
@@ -14,17 +14,9 @@
 
 ####################### SECTION 1: Packages, file paths, etc #########################
 
-## Libraries
+# Libraries
 library(reshape2)
 
-# Source in global functions/themes script
-# source("Master RMarkdown Document & Render Code/Global Script.R")
-
-## Final document will loop through a list of localities
-# Create placeholder for for loop
-# LOCALITY <- "Inverness"
-# LOCALITY <- "Stirling City with the Eastern Villages Bridge of Allan and Dunblane"
-# LOCALITY <- "Ayr North and Former Coalfield Communities"
 
 ########################## SECTION 2: Data Imports ###############################
 
@@ -41,6 +33,17 @@ hscp_pop_proj <- read_in_pop_proj()
 pop_max_year <- max(pop_raw_data$year)
 pop_min_year <- pop_max_year - 5
 
+# Testing setup ----
+# Source in global functions/themes script
+# source("Master RMarkdown Document & Render Code/Global Script.R")
+
+# Select one locality e.g. by commenting out one line
+# LOCALITY <- "Inverness"
+# LOCALITY <- "Stirling City with the Eastern Villages Bridge of Allan and Dunblane"
+# LOCALITY <- "Ayr North and Former Coalfield Communities"
+
+# This will set the HSCP for the chosen locality. Testing only.
+# HSCP <- get_hscp_from_locality(LOCALITY, lookup)
 
 ######################## SECTION 3: Gender and Age #############################
 
@@ -495,9 +498,6 @@ rm(
 
 ##################### SECTION 5: Objects for summary table #######################
 
-## Relevant lookups for creating the table objects
-HSCP <- as.character(filter(lookup, hscp_locality == LOCALITY)$hscp2019name)
-
 # Determine other localities based on LOCALITY object
 other_locs <- lookup %>%
   select(hscp_locality, hscp2019name) %>%
@@ -520,7 +520,6 @@ over65 <- round_half_up(
     100,
   1
 )
-
 
 ## Other localities in HSCP objects
 

--- a/Demographics/1. Demographics - Population.R
+++ b/Demographics/1. Demographics - Population.R
@@ -5,17 +5,9 @@
 
 ####################### SECTION 1: Packages, file paths, etc #########################
 
-## Libraries
+# Libraries
 library(reshape2)
 
-# Source in global functions/themes script
-#source("Master RMarkdown Document & Render Code/Global Script.R")
-
-## Final document will loop through a list of localities
-# Create placeholder for for loop
-#LOCALITY <- "Inverness"
-# LOCALITY <- "Stirling City with the Eastern Villages Bridge of Allan and Dunblane"
-# LOCALITY <- "Ayr North and Former Coalfield Communities"
 
 ########################## SECTION 2: Data Imports ###############################
 
@@ -32,6 +24,17 @@ hscp_pop_proj <- read_in_pop_proj()
 pop_max_year <- max(pop_raw_data$year)
 pop_min_year <- pop_max_year - 5
 
+# Testing setup ----
+# Source in global functions/themes script
+# source("Master RMarkdown Document & Render Code/Global Script.R")
+
+# Select one locality e.g. by commenting out one line
+# LOCALITY <- "Inverness"
+# LOCALITY <- "Stirling City with the Eastern Villages Bridge of Allan and Dunblane"
+# LOCALITY <- "Ayr North and Former Coalfield Communities"
+
+# This will set the HSCP for the chosen locality. Testing only.
+# HSCP <- get_hscp_from_locality(LOCALITY, lookup)
 
 ######################## SECTION 3: Gender and Age #############################
 
@@ -486,9 +489,6 @@ rm(
 
 ##################### SECTION 5: Objects for summary table #######################
 
-## Relevant lookups for creating the table objects
-HSCP <- as.character(filter(lookup, hscp_locality == LOCALITY)$hscp2019name)
-
 # Determine other localities based on LOCALITY object
 other_locs <- lookup %>%
   select(hscp_locality, hscp2019name) %>%
@@ -511,7 +511,6 @@ over65 <- round_half_up(
     100,
   1
 )
-
 
 ## Other localities in HSCP objects
 

--- a/Demographics/2. Demographics - SIMD.R
+++ b/Demographics/2. Demographics - SIMD.R
@@ -35,8 +35,14 @@ library(sf)
 
 # SECTION 2: Data Imports ----
 
+## Relevant lookups for creating the table objects
+lookup <- read_in_localities()
+
 ## Locality/DZ lookup
 lookup_dz <- read_in_localities(dz_level = TRUE)
+
+# This will set the HSCP for the chosen locality. Testing only.
+# HSCP <- get_hscp_from_locality(LOCALITY, lookup)
 
 ## Population data
 pop_raw_data <- read_in_dz_pops()
@@ -464,12 +470,6 @@ simd_diff_overall <- simd_16_20_dom %>%
 
 
 ##################### SECTION 4: Objects for summary table #######################
-
-## Relevant lookups for creating the table objects
-lookup <- read_in_localities()
-
-## Relevant lookups for creating the table objects
-HSCP <- as.character(filter(lookup, hscp_locality == LOCALITY)$hscp2019name)
 
 # Determine other localities based on LOCALITY object
 other_locs <- lookup %>%

--- a/Households/Households Code.R
+++ b/Households/Households Code.R
@@ -36,6 +36,17 @@ ext_year <- 2025
 #LOCALITY <- "Inverness"
 # LOCALITY <- "Ayr North and Former Coalfield Communities"
 
+# Global Script Function to read in Localities Lookup
+lookup <- read_in_localities(dz_level = TRUE) %>%
+  select(datazone2011, hscp_locality) %>%
+  filter(hscp_locality == LOCALITY)
+
+# Global Script Function to read in Localities Lookup
+lookup2 <- read_in_localities(dz_level = FALSE)
+
+# This will set the HSCP for the chosen locality. Testing only.
+# HSCP <- get_hscp_from_locality(LOCALITY, lookup2)
+
 ##################### Section 2 - Households Data #############################
 
 ## 2a) Data imports & cleaning ----
@@ -60,11 +71,6 @@ house_raw_dat <- map(
   }
 ) |>
   list_rbind()
-
-# Global Script Function to read in Localities Lookup
-lookup <- read_in_localities(dz_level = TRUE) %>%
-  select(datazone2011, hscp_locality) %>%
-  filter(hscp_locality == LOCALITY)
 
 
 # filter housing data for locality of interest
@@ -283,12 +289,6 @@ perc_houses_FH <- format_number_for_text(
 ########################## Section 4 - Objects for Summary Table ########################
 
 ## Relevant lookups for creating the table objects
-
-# Global Script Function to read in Localities Lookup
-lookup2 <- read_in_localities(dz_level = FALSE)
-
-# Determine HSCP and HB based on Loc
-HSCP <- as.character(filter(lookup2, hscp_locality == LOCALITY)$hscp2019name)
 
 # Determine other localities based on LOCALITY object
 other_locs <- lookup2 %>%

--- a/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
+++ b/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
@@ -34,9 +34,10 @@ ext_year <- 2025
 # Locality lookup
 lookup <- read_in_localities()
 
-# Determine HSCP and HB based on Loc
-HSCP <- as.character(filter(lookup, hscp_locality == LOCALITY)$hscp2019name)
-HB <- as.character(filter(lookup, hscp_locality == LOCALITY)$hb2019name)
+# This will set the HSCP for the chosen locality. Testing only.
+# HSCP <- get_hscp_from_locality(LOCALITY, lookup)
+# This sets the HB
+HB <- get_hb_from_locality(LOCALITY, lookup)
 
 # Determine other localities based on LOCALITY object
 other_locs <- lookup %>%

--- a/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
+++ b/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
@@ -33,9 +33,10 @@ trend_years <- 10
 # Locality lookup
 lookup <- read_in_localities()
 
-# Determine HSCP and HB based on Loc
-HSCP <- as.character(filter(lookup, hscp_locality == LOCALITY)$hscp2019name)
-HB <- as.character(filter(lookup, hscp_locality == LOCALITY)$hb2019name)
+# This will set the HSCP for the chosen locality. Testing only.
+# HSCP <- get_hscp_from_locality(LOCALITY, lookup)
+# This sets the HB
+HB <- get_hb_from_locality(LOCALITY, lookup)
 
 # Determine other localities based on LOCALITY object
 other_locs <- lookup %>%

--- a/Master RMarkdown Document & Render Code/Global Script.R
+++ b/Master RMarkdown Document & Render Code/Global Script.R
@@ -195,6 +195,24 @@ count_localities <- function(locality_lookup, hscp_name) {
   return(sum(locality_lookup[["hscp2019name"]] == hscp_name))
 }
 
+get_hscp_from_locality <- function(
+  locality_name,
+  localities_lookup = read_in_localities()
+) {
+  localities_lookup[["hscp2019name"]][
+    localities_lookup[["hscp_locality"]] == locality_name
+  ]
+}
+
+get_hb_from_locality <- function(
+  locality_name,
+  localities_lookup = read_in_localities()
+) {
+  localities_lookup[["hb2019name"]][
+    localities_lookup[["hscp_locality"]] == locality_name
+  ]
+}
+
 ## Function to read in latest SPD file ----
 
 # No arguments needed, just use read_in_latest_postcodes()

--- a/Population Health/3. Population Health Outputs.R
+++ b/Population Health/3. Population Health Outputs.R
@@ -44,9 +44,11 @@ pop_health_data_dir_LE <- path(
 # Locality lookup
 lookup <- read_in_localities()
 
-# Determine HSCP and HB based on Locality
-HSCP <- filter(lookup, hscp_locality == LOCALITY)[["hscp2019name"]]
-HB <- filter(lookup, hscp_locality == LOCALITY)[["hb2019name"]]
+# This will set the HSCP for the chosen locality. Testing only.
+# HSCP <- get_hscp_from_locality(LOCALITY, lookup)
+
+# This will set the HB
+HB <- get_hb_from_locality(LOCALITY, lookup)
 
 # Determine other localities based on LOCALITY object
 other_locs <- lookup |>

--- a/Population Health/3. Population Health Outputs.R
+++ b/Population Health/3. Population Health Outputs.R
@@ -42,9 +42,11 @@ pop_health_data_dir <- path(
 # Locality lookup
 lookup <- read_in_localities()
 
-# Determine HSCP and HB based on Locality
-HSCP <- filter(lookup, hscp_locality == LOCALITY)[["hscp2019name"]]
-HB <- filter(lookup, hscp_locality == LOCALITY)[["hb2019name"]]
+# This will set the HSCP for the chosen locality. Testing only.
+# HSCP <- get_hscp_from_locality(LOCALITY, lookup)
+
+# This will set the HB
+HB <- get_hb_from_locality(LOCALITY, lookup)
 
 # Determine other localities based on LOCALITY object
 other_locs <- lookup |>

--- a/Services/2. Services data manipulation & table.R
+++ b/Services/2. Services data manipulation & table.R
@@ -31,8 +31,8 @@ lookup <- read_in_localities(dz_level = TRUE)
 # Lookup without datazones
 lookup2 <- read_in_localities()
 
-## Determine HSCP
-HSCP <- as.character(filter(lookup2, hscp_locality == LOCALITY)$hscp2019name)
+# This will set the HSCP for the chosen locality. Testing only.
+# HSCP <- get_hscp_from_locality(LOCALITY, lookup)
 
 # Get number of localities in HSCP
 n_loc <- count_localities(lookup2, HSCP)

--- a/Unscheduled Care/2. Unscheduled Care outputs.R
+++ b/Unscheduled Care/2. Unscheduled Care outputs.R
@@ -39,8 +39,11 @@ max_fy <- "2024/25" # TODO Change this to be dynamic and move to general!
 
 localities <- read_in_localities()
 
-HSCP <- as.character(filter(localities, hscp_locality == LOCALITY)$hscp2019name)
-HB <- as.character(filter(localities, hscp_locality == LOCALITY)$hb2019name)
+# This will set the HSCP for the chosen locality. Testing only.
+# HSCP <- get_hscp_from_locality(LOCALITY, lookup)
+
+# This will set the HB
+HB <- get_hb_from_locality(LOCALITY, lookup)
 
 # Determine other localities based on LOCALITY object
 other_locs <- localities %>%


### PR DESCRIPTION
`HSCP` should only be assigned during testing scenarios. In typical cases, when we're running in a loop, overwriting `HSCP` could lead to issues.

This update comments out all instances where `HSCP` was being assigned.

Additionally, it introduces two new functions: one for retrieving the `HSCP` name from `LOCALITY` and another for obtaining the `HB` name. These functions have been implemented consistently throughout the code.