### PR TITLE
Replace nested ifelse blocks

### DIFF
--- a/Demographics/1. Demographics - Population.R
+++ b/Demographics/1. Demographics - Population.R
@@ -415,66 +415,42 @@ pop_change <- case_when(
   .default = "been falling since"
 )
 
-pop_graph_text <- ifelse(
-  pval < 0.05,
-
-  # if the pvalue is less than .05 then return:
-  paste0(
-    "The population has been ",
-
-    # determine whether its rising or falling:
-    ifelse(coef < 0, "falling", "rising"),
-
-    # could have trend that has changed in recent years
-    ifelse(
-      coef < 0 & pop_latest > pop_last,
-      " in general, however it has risen since last year.",
-      ifelse(
-        coef > 0 & pop_latest < pop_last,
-        " in general, however it has fallen since last year.",
-        "."
-      )
-    )
-  ),
-
-  # if the pvalue is not significant then return:
-  paste0(
-    paste(
-      "There is no significant linear trend in population.",
-      "However, it has",
-      pop_change,
-      change_point
-    ),
-    "."
+pop_graph_text <- case_when(
+  pval < 0.05 & coef < 0 & pop_latest > pop_last ~
+    "The population has been falling in general, however it has risen since last year.",
+  pval < 0.05 & coef > 0 & pop_latest < pop_last ~
+    "The population has been rising in general, however it has fallen since last year.",
+  pval < 0.05 & coef < 0 ~ "The population has been falling.",
+  pval < 0.05 & coef > 0 ~ "The population has been rising.",
+  .default = glue(
+    "There is no significant linear trend in population. However, it has {pop_change} {change_point}."
   )
-) %>%
-  paste()
-
-## Pop projection
-pop_proj_change <- 100 *
-  abs(pop_proj_dat[1, 2] - pop_proj_dat[6, 2]) /
-  pop_proj_dat[1, 2]
-pop_proj_change <- round_half_up(pop_proj_change, 1) %>% as.character()
-
-pop_proj_text <- paste(
-  "The population in",
-  LOCALITY,
-  "is estimated to",
-  ifelse(
-    pop_proj_dat[1, 2] < pop_proj_dat[6, 2],
-    paste0("increase by ", pop_proj_change, "%"),
-    ifelse(
-      pop_proj_dat[1, 2] == pop_proj_dat[6, 2],
-      "remain the same",
-      paste0("decrease by ", pop_proj_change, "%")
-    )
-  ),
-  "from ",
-  pop_proj_dat[1, 1],
-  " to ",
-  pop_proj_dat[6, 1]
 )
 
+## Pop projection
+pop_proj_min_year <- min(pop_proj_dat[["year"]])
+pop_proj_min_year_value <- filter(pop_proj_dat, year == pop_proj_min_year) |>
+  pull(pop)
+pop_proj_max_year <- max(pop_proj_dat[["year"]])
+pop_proj_max_year_value <- filter(pop_proj_dat, year == pop_proj_max_year) |>
+  pull(pop)
+
+pop_proj_change_pct <- round_half_up(
+  100 *
+    (pop_proj_max_year_value - pop_proj_min_year_value) /
+    pop_proj_min_year_value,
+  digits = 1L
+)
+
+pop_proj_text <- glue(
+  "The population in {LOCALITY} is estimated to ",
+  case_when(
+    pop_proj_change_pct > 0 ~ glue("increase by {pop_proj_change_pct}%"),
+    pop_proj_change_pct < 0 ~ glue("decrease by {abs(pop_proj_change_pct)}%"),
+    .default = "remain the same"
+  ),
+  " from {pop_proj_min_year} to {pop_proj_max_year}"
+)
 
 rm(
   reg,

--- a/Demographics/1. Demographics - Population.R
+++ b/Demographics/1. Demographics - Population.R
@@ -409,10 +409,10 @@ change_point <- ifelse(
   change_point
 )
 
-pop_change <- ifelse(
-  pop_latest > pop_last,
-  "been rising since",
-  ifelse(pop_latest == pop_last, "remained the same as", "been falling since")
+pop_change <- case_when(
+  pop_latest > pop_last ~ "been rising since",
+  pop_latest == pop_last ~ "remained the same as",
+  .default = "been falling since"
 )
 
 pop_graph_text <- ifelse(

--- a/Master RMarkdown Document & Render Code/Global Script.R
+++ b/Master RMarkdown Document & Render Code/Global Script.R
@@ -48,19 +48,13 @@ palette <- phsstyles::phs_colours(c(
 ## Function for formatting a value for R Markdown text
 # First determines how many dps the value should have
 # Then adds a comma for numbers over 1000 (becomes "1,000")
-
-format_number_for_text <- function(x) {
-  x <- ifelse(
-    abs(x) < 1,
-    round_half_up(x, 2), # if x < 1 then show 2dp
-    ifelse(
-      abs(x) < 100,
-      round_half_up(x, 1), # if 1 =< x < 100 then 1dp
-      round_half_up(x)
-    )
-  ) # if 10 =< x then no decimal places
-
-  format(x, big.mark = ",")
+format_number_for_text <- function(number) {
+  case_when(
+    abs(number) < 1 ~ round_half_up(number, 2),
+    abs(number) < 100 ~ round_half_up(number, 1),
+    .default = round_half_up(number, 0)
+  ) |>
+    format(big.mark = ",")
 }
 
 # This will return the correct article depending on the (max 2-digit) number supplied


### PR DESCRIPTION
Suggested by `{lintr}`

> Calling [ifelse()](https://pwb-prod.publichealthscotland.org/s/3aeb4e6bb9555181e541f/help/library/lintr/help/ifelse) in nested calls is problematic for two main reasons:
> 1. It can be hard to read – mapping the code to the expected output for such code can be a messy task/require a lot of mental bandwidth, especially for code that nests more than once
> 2. It is inefficient – ifelse() can evaluate all of its arguments at both yes and no (see https://stackoverflow.com/q/16275149); this issue is exacerbated for nested calls

I think the code is significantly more readable now, however, ensuring it's functionally the same is a bit tricky, especially for the more complicated block in Demographics!