### PR TITLE
Don't use regex when it's not needed

### DIFF
--- a/Demographics/1. Demographics - Population.R
+++ b/Demographics/1. Demographics - Population.R
@@ -133,8 +133,10 @@ pop_breakdown <- pops %>%
       gsub(
         "Plus",
         "+",
-        gsub("Pop", "", variable)
-      )
+        gsub("Pop", "", variable, fixed = TRUE),
+        fixed = TRUE
+      ),
+      fixed = TRUE
     )
   ) %>%
   rename(Gender = sex, Age = variable, Population = value) %>%
@@ -187,14 +189,9 @@ hist_pop_breakdown <- pops %>%
   select(-hscp_locality, -total_pop, -hscp2019name, -Pop65Plus) %>%
   reshape2::melt(id.vars = c("sex", "year")) %>%
   mutate(
-    variable = gsub(
-      "_",
-      "-",
-      gsub(
-        "Plus",
-        "+",
-        gsub("Pop", "", variable)
-      )
+    variable = str_replace_all(
+      variable,
+      c("Pop" = fixed(""), "Plus" = fixed("+"), "_" = fixed("-"))
     )
   ) %>%
   rename(Gender = sex, Age = variable, Population = value) %>%

--- a/Demographics/2. Demographics - SIMD.R
+++ b/Demographics/2. Demographics - SIMD.R
@@ -353,7 +353,7 @@ simd2016_dom <- simd2016_dom %>%
   ) %>%
   mutate(
     perc_16 = pop / total_pop,
-    domain = gsub("_16", "", variable)
+    domain = gsub("_16", "", variable, fixed = TRUE)
   ) %>%
   ungroup() %>%
   select(domain, perc_16, quintile = value)
@@ -371,7 +371,7 @@ simd2020_dom <- simd2020_dom %>%
   ) %>%
   mutate(
     perc_20 = pop / total_pop,
-    domain = gsub("_20", "", variable)
+    domain = gsub("_20", "", variable, fixed = TRUE)
   ) %>%
   ungroup() %>%
   select(domain, perc_20, quintile = value)

--- a/General Health/3. General Health Outputs.R
+++ b/General Health/3. General Health Outputs.R
@@ -90,7 +90,7 @@ deaths_15_44 <- read_parquet(path(
   "scotpho_data_extract_deaths_15_44.parquet"
 )) %>%
   clean_scotpho_dat() %>%
-  mutate(period_short = gsub("to", "-", substr(period, 1, 12)))
+  mutate(period_short = gsub("to", "-", substr(period, 1, 12), fixed = TRUE))
 
 check_missing_data_scotpho(deaths_15_44)
 
@@ -100,7 +100,7 @@ cancer_reg <- read_parquet(path(
   "scotpho_data_extract_cancer_reg.parquet"
 )) %>%
   clean_scotpho_dat() %>%
-  mutate(period_short = gsub("to", "-", substr(period, 1, 12)))
+  mutate(period_short = gsub("to", "-", substr(period, 1, 12), fixed = TRUE))
 
 check_missing_data_scotpho(cancer_reg)
 
@@ -110,7 +110,7 @@ early_deaths_cancer <- read_parquet(path(
   "scotpho_data_extract_early_deaths_cancer.parquet"
 )) %>%
   clean_scotpho_dat() %>%
-  mutate(period_short = gsub("to", "-", substr(period, 1, 12)))
+  mutate(period_short = gsub("to", "-", substr(period, 1, 12), fixed = TRUE))
 
 check_missing_data_scotpho(early_deaths_cancer)
 
@@ -121,7 +121,7 @@ asthma_hosp <- read_parquet(path(
   "scotpho_data_extract_asthma_hosp.parquet"
 )) %>%
   clean_scotpho_dat() %>%
-  mutate(period_short = gsub("to", "-", substr(period, 1, 18)))
+  mutate(period_short = gsub("to", "-", substr(period, 1, 18), fixed = TRUE))
 
 check_missing_data_scotpho(asthma_hosp)
 
@@ -131,7 +131,7 @@ chd_hosp <- read_parquet(path(
   "scotpho_data_extract_chd_hosp.parquet"
 )) %>%
   clean_scotpho_dat() %>%
-  mutate(period_short = gsub("to", "-", substr(period, 1, 18)))
+  mutate(period_short = gsub("to", "-", substr(period, 1, 18), fixed = TRUE))
 
 check_missing_data_scotpho(chd_hosp)
 
@@ -141,7 +141,7 @@ copd_hosp <- read_parquet(path(
   "scotpho_data_extract_copd_hosp.parquet"
 )) %>%
   clean_scotpho_dat() %>%
-  mutate(period_short = gsub("to", "-", substr(period, 1, 18)))
+  mutate(period_short = gsub("to", "-", substr(period, 1, 18), fixed = TRUE))
 
 check_missing_data_scotpho(copd_hosp)
 
@@ -175,8 +175,10 @@ ltc <- read_parquet(path(gen_health_data_dir, "LTC_from_SLF.parquet")) %>%
     "Parkinsons" = "parkinsons",
     "Renal failure" = "refailure"
   ) %>%
-  mutate(hscp_locality = gsub("&", "and", hscp_locality)) %>%
-  mutate(year = paste0("20", substr(year, 1, 2), "/", substr(year, 3, 4)))
+  mutate(
+    hscp_locality = gsub("&", "and", hscp_locality, fixed = TRUE),
+    year = paste0("20", substr(year, 1, 2), "/", substr(year, 3, 4))
+  )
 
 
 ############################### 2) SCOTPHO DATA ####################################
@@ -456,9 +458,9 @@ disease_hosp <- bind_rows(
   ) %>%
   mutate(
     indicator = case_when(
-      str_detect(indicator, "Asthma") ~ "Asthma",
-      str_detect(indicator, "CHD") ~ "Coronary Heart Disease",
-      str_detect(indicator, "COPD") ~ "COPD"
+      str_detect(indicator, fixed("Asthma")) ~ "Asthma",
+      str_detect(indicator, fixed("CHD")) ~ "Coronary Heart Disease",
+      str_detect(indicator, fixed("COPD")) ~ "COPD"
     )
   ) %>%
   mutate(measure = round_half_up(measure, 1))
@@ -475,7 +477,7 @@ disease_hosp_table <- disease_hosp |>
     area_order = case_when(
       area_name == LOCALITY ~ 1L,
       area_name == HSCP ~ 2L,
-      str_starts(area_name, "NHS") ~ 4L,
+      str_starts(area_name, fixed("NHS")) ~ 4L,
       area_name == "Scotland" ~ 5L,
       .default = 2L
     )

--- a/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
+++ b/Lifestyle & Risk Factors/2. Lifestyle & Risk Factors Outputs.R
@@ -58,7 +58,7 @@ drug_hosp <- readRDS(paste0(
   "/scotpho_data_extract_drug_hosp.RDS"
 )) %>%
   clean_scotpho_dat() %>%
-  mutate(period_short = gsub("to", "-", substr(period, 1, 18)))
+  mutate(period_short = gsub("to", "-", substr(period, 1, 18), fixed = TRUE))
 
 check_missing_data_scotpho(drug_hosp)
 
@@ -84,7 +84,7 @@ alcohol_deaths <- readRDS(paste0(
   "/scotpho_data_extract_alcohol_deaths.RDS"
 )) %>%
   clean_scotpho_dat() %>%
-  mutate(period_short = gsub("to", "-", substr(period, 1, 12)))
+  mutate(period_short = gsub("to", "-", substr(period, 1, 12), fixed = TRUE))
 
 check_missing_data_scotpho(alcohol_deaths)
 
@@ -96,7 +96,7 @@ bowel_screening <- readRDS(paste0(
   "/scotpho_data_extract_bowel_screening.RDS"
 )) %>%
   clean_scotpho_dat() %>%
-  mutate(period_short = gsub("to", "-", substr(period, 1, 12)))
+  mutate(period_short = gsub("to", "-", substr(period, 1, 12), fixed = TRUE))
 
 check_missing_data_scotpho(bowel_screening)
 

--- a/Master RMarkdown Document & Render Code/Global Script.R
+++ b/Master RMarkdown Document & Render Code/Global Script.R
@@ -293,7 +293,7 @@ read_in_pop_proj <- function() {
 clean_scotpho_dat <- function(data) {
   data %>%
     filter(area_type != "Council area" & area_type != "Intermediate zone") %>%
-    mutate(area_name = gsub("&", "and", area_name)) %>%
+    mutate(area_name = gsub("&", "and", area_name, fixed = TRUE)) %>%
     mutate(
       area_name = if_else(
         area_name == "Renfrewshire West",

--- a/Services/2. Services data manipulation & table.R
+++ b/Services/2. Services data manipulation & table.R
@@ -47,7 +47,7 @@ n_loc <- count_localities(lookup2, HSCP)
 ## Read in Postcode file for latitudes and longitudes
 
 postcode_lkp <- read_in_postcodes() %>%
-  mutate(postcode = gsub(" ", "", pc7)) %>%
+  mutate(postcode = gsub(" ", "", pc7, fixed = TRUE)) %>%
   select(
     postcode,
     grid_reference_easting,
@@ -93,7 +93,7 @@ rm(curr, hosp, MDSF)
 
 prac <- prac %>%
   select(practice_code, gp_practice_name, practice_list_size, postcode) %>%
-  mutate(postcode = gsub(" ", "", postcode))
+  mutate(postcode = gsub(" ", "", postcode, fixed = TRUE))
 
 # Merge practice data with postcode and locality lookups
 markers_gp <- left_join(prac, postcode_lkp, by = "postcode") %>%
@@ -119,7 +119,7 @@ hosp_lookup <- hosp_types %>%
     select(hosp_postcodes, location, postcode),
     by = join_by(location)
   ) %>%
-  mutate(postcode = gsub(" ", "", postcode)) %>%
+  mutate(postcode = gsub(" ", "", postcode, fixed = TRUE)) %>%
   left_join(postcode_lkp, by = "postcode")
 
 # MIUs
@@ -160,7 +160,7 @@ markers_care_home <- care_homes %>%
   ) %>%
   filter(type == "Care Home Service") %>%
   filter(subtype == "Older People") %>%
-  mutate(postcode = gsub(" ", "", service_postcode)) %>%
+  mutate(postcode = gsub(" ", "", service_postcode, fixed = TRUE)) %>%
   left_join(postcode_lkp, by = "postcode") %>%
   filter(hscp2019name == HSCP)
 
@@ -177,7 +177,7 @@ other_care_type <- care_homes %>%
   ) %>%
   filter(type == "Care Home Service") %>%
   filter(subtype != "Older People") %>%
-  mutate(postcode = gsub(" ", "", service_postcode)) %>%
+  mutate(postcode = gsub(" ", "", service_postcode, fixed = TRUE)) %>%
   left_join(postcode_lkp, by = "postcode") %>%
   filter(hscp_locality == LOCALITY)
 

--- a/Services/3. Service HSCP map.R
+++ b/Services/3. Service HSCP map.R
@@ -38,7 +38,7 @@ shp <- st_transform(shp, 4326) |>
   select(hscp_local, HSCP_name, Shape_Leng, Shape_Area, geometry)
 
 shp <- shp |>
-  mutate(hscp_locality = gsub("&", "and", hscp_local)) |>
+  mutate(hscp_locality = gsub("&", "and", hscp_local, fixed = TRUE)) |>
   merge(lookup2, by = "hscp_locality")
 
 shp_hscp <- shp |>
@@ -145,7 +145,7 @@ places <- read_csv(paste0(
     type = first(type)
   ) |>
   st_as_sf(coords = c("Longitude", "Latitude"), remove = FALSE, crs = 4326) |>
-  filter(!grepl("_", name)) |> # filter incorrect name types
+  filter(!grepl("_", name, fixed = TRUE)) |> # filter incorrect name types
   filter(type != "hamlet" & type != "village") # remove smaller places
 
 # 3.3 Background map ----

--- a/Unscheduled Care/1. Unscheduled Care data extraction.R
+++ b/Unscheduled Care/1. Unscheduled Care data extraction.R
@@ -83,7 +83,7 @@ msg_mh_beddays_raw <- read_parquet(paste0(
 msg_emergency_adm <- msg_emerg_adm_raw %>%
   mutate(age_group = age_group_1(age_group)) %>%
   mutate(financial_year = phsmethods::extract_fin_year(month)) %>%
-  mutate(hscp_locality = gsub("&", "and", locality)) %>%
+  mutate(hscp_locality = gsub("&", "and", locality, fixed = TRUE)) %>%
   # join with localities lookup to get hscp
   left_join(localities, by = "hscp_locality") %>%
   # aggregate
@@ -98,7 +98,7 @@ msg_emergency_adm <- msg_emerg_adm_raw %>%
 msg_bed_days <- msg_beddays_raw %>%
   mutate(age_group = age_group_1(age_group)) %>%
   mutate(financial_year = phsmethods::extract_fin_year(month)) %>%
-  mutate(hscp_locality = gsub("&", "and", locality)) %>%
+  mutate(hscp_locality = gsub("&", "and", locality, fixed = TRUE)) %>%
   # join with localities lookup to get hscp
   left_join(localities, by = "hscp_locality") %>%
   # aggregate
@@ -113,7 +113,7 @@ msg_bed_days <- msg_beddays_raw %>%
 msg_bed_days_mh <- msg_mh_beddays_raw %>%
   mutate(age_group = age_group_1(age_group)) %>%
   mutate(financial_year = phsmethods::extract_fin_year(month)) %>%
-  mutate(hscp_locality = gsub("&", "and", locality)) %>%
+  mutate(hscp_locality = gsub("&", "and", locality, fixed = TRUE)) %>%
   # join with localities lookup to get hscp
   left_join(localities, by = "hscp_locality") %>%
   # aggregate
@@ -128,7 +128,7 @@ msg_bed_days_mh <- msg_mh_beddays_raw %>%
 msg_ae <- msg_ae_raw %>%
   mutate(age_group = age_group_1(age_group)) %>%
   mutate(financial_year = phsmethods::extract_fin_year(month)) %>%
-  mutate(hscp_locality = gsub("&", "and", locality)) %>%
+  mutate(hscp_locality = gsub("&", "and", locality, fixed = TRUE)) %>%
   # join with localities lookup to get hscp
   left_join(localities, by = "hscp_locality") %>%
   # aggregate
@@ -143,9 +143,9 @@ msg_ae <- msg_ae_raw %>%
 msg_dd <- msg_dd_raw %>%
   mutate(age_group = age_group_1(age_group)) %>%
   mutate(financial_year = phsmethods::extract_fin_year(month)) %>%
-  mutate(hscp_locality = gsub("&", "and", locality)) %>%
+  mutate(hscp_locality = gsub("&", "and", locality, fixed = TRUE)) %>%
   # this data set has some data with partnership but no locality, need to tidy names
-  mutate(hscp2019name = gsub("&", "and", council)) %>%
+  mutate(hscp2019name = gsub("&", "and", council, fixed = TRUE)) %>%
   mutate(hscp2019name = ptsp(hscp2019name)) %>%
   group_by(
     financial_year,

--- a/Unscheduled Care/2. Unscheduled Care outputs.R
+++ b/Unscheduled Care/2. Unscheduled Care outputs.R
@@ -1931,7 +1931,7 @@ psych_hosp <- read_csv(paste0(
   "scotpho_data_extract_psychiatric_admissions.csv"
 )) %>%
   clean_scotpho_dat() %>%
-  mutate(period_short = gsub("to", "-", substr(period, 1, 18)))
+  mutate(period_short = gsub("to", "-", substr(period, 1, 18), fixed = TRUE))
 
 check_missing_data_scotpho(psych_hosp)
 


### PR DESCRIPTION
>Invoking a regular expression engine is overkill for cases when the search pattern only involves static patterns.

This is the case for most of our calls, so these have been updated with `fixed = TRUE` for `grep` type calls and `fixed()` for `{stringr}`.

Each expression should be faster, which should help the overall process.