### PR TITLE
Update .lintr to exlude the implicit_integer_linter

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,7 @@
 linters: all_linters(
   absolute_path_linter = NULL,
   commented_code_linter = NULL,
+  implicit_integer_linter = NULL,
   line_length_linter = line_length_linter(length = 100L),
   missing_package_linter = NULL,
   object_name_linter = object_name_linter(styles = "snake_case"),


### PR DESCRIPTION
This will mean the [implicit_integer_linter](https://lintr.r-lib.org/reference/implicit_integer_linter.html) will no longer be used. It was flagging on *a lot* of lines, and I'm not sure that we actually want to resolve it, as using explicit integers / reals hurts readability.