### PR TITLE
0002 allows group file manipulation

### DIFF
--- a/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
+++ b/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
@@ -5,7 +5,7 @@ library(rmarkdown)
 rm(list = ls())
 
 # system unmask function so files have read-write permissions
-Sys.umask("0002")
+Sys.umask("000")
 
 # Source in functions code
 source("Master RMarkdown Document & Render Code/Global Script.R")


### PR DESCRIPTION
Hi folks, if someone could run the render code in this branch as a test using the Renfrewshire partnership as the test HSCP, that should indicate if `sys.unmask(0002)` over `006` works. 

**Some AI guidance of sorts**
**umask 0002 is the standard for shared group environments:**

- The owner and group have full permissions (read/write).

- Others can read but cannot write.

 - This lets your team members (in the same group) edit files while others just have read access.

**umask 006 is unusual and restrictive:**

- Owner and group have full permissions.

- Others lose both read and write permissions, but strangely keep execute permission.

- This can block others from even reading files, which is often too restrictive for shared projects.


The difference actually happens if your directory group ownership or permissions are different, or your files or parent directories have restrictive permissions, or more importantly:

umask 006 affects only others, but if your files/folders are set with private group ownership (your username as group), other group members are actually "others" in permission terms.

If the directory group is your username (private group), your teammates are "others" and get the restricted --x permission (execute only, no write).

**There may also be another way to do this via terminal commands and group creation but i'm not sure sys.umask(0002) seems manageable for now anyway**