### PR TITLE
Use the IZ boundaries and lookup to build new 'Locality' boundaries for the map

### DIFF
--- a/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
+++ b/Master RMarkdown Document & Render Code/Locality Profiles Render Code.R
@@ -68,7 +68,7 @@ for (LOCALITY in locality_list) {
 
   # Services ----
   source("Services/2. Services data manipulation & table.R")
-  #source("Services/3. Service HSCP map.R")
+  source("Services/3. Service HSCP map.R")
 
   # General Health ----
   source("General Health/3. General Health Outputs.R")

--- a/Services/3. Service HSCP map.R
+++ b/Services/3. Service HSCP map.R
@@ -36,9 +36,9 @@ shp_hscp <- read_sf(
 ) |>
   st_transform(crs = 4326) |>
   inner_join(
-  read_in_iz(),
-  by = join_by(InterZone == intzone2011)
-) |>
+    read_in_iz(),
+    by = join_by(InterZone == intzone2011)
+  ) |>
   group_by(hscp_locality) |>
   summarise(
     geometry = st_union(geometry)


### PR DESCRIPTION
This uses the Intermediate Zone shape files to build up a new set of boundaries for the custom localities using the custom lookups.

Other than the read in at the top, the other changes are really code clean up and could probably be applied to the 'main' map code!