### PR TITLE
Use memoise to cache functions for a speedup

### DIFF
--- a/Master RMarkdown Document & Render Code/Global Script.R
+++ b/Master RMarkdown Document & Render Code/Global Script.R
@@ -21,6 +21,7 @@ library(glue)
 library(fs)
 library(arrow)
 library(phsstyles)
+library(memoise)
 
 # Prefer dplyr functions if there's a conflict
 conflicted::conflict_prefer_all("dplyr", quiet = TRUE)
@@ -153,7 +154,7 @@ theme_profiles <- function() {
 # default is F - datazones are not imported, there is one line per locality (125 rows)
 # if changed to dz_level = TRUE, this shows all the datazones in each locality (6976 rows)
 
-read_in_localities <- function(dz_level = FALSE) {
+read_in_localities_raw <- function(dz_level = FALSE) {
   data <- fs::dir_ls(
     path = "/conf/linkage/output/lookups/Unicode/Geography/HSCP Locality",
     regexp = "HSCP Localities_DZ11_Lookup_.+?\\.rds$"
@@ -184,6 +185,7 @@ read_in_localities <- function(dz_level = FALSE) {
 
   return(data)
 }
+read_in_localities <- memoise(read_in_localities_raw)
 
 count_localities <- function(locality_lookup, hscp_name) {
   return(sum(locality_lookup[["hscp2019name"]] == hscp_name))
@@ -194,7 +196,7 @@ count_localities <- function(locality_lookup, hscp_name) {
 # No arguments needed, just use read_in_latest_postcodes()
 # The function pulls the latest "Scottish_Postcode_Directory_year_version.rds"
 
-read_in_postcodes <- function() {
+read_in_postcodes_raw <- function() {
   data <- fs::dir_ls(
     path = "/conf/linkage/output/lookups/Unicode/Geography/Scottish Postcode Directory",
     regexp = "\\.parquet$"
@@ -214,7 +216,7 @@ read_in_postcodes <- function() {
 
   return(data)
 }
-
+read_in_postcodes <- memoise(read_in_postcodes_raw)
 
 ## Function to read in the latest population file by DZ ----
 
@@ -222,7 +224,7 @@ read_in_postcodes <- function() {
 # Function pulls the latest DZ populations DataZone2011_pop_est_2011_Xyear.rds
 # Then joins this with the localities lookup to match hscp_locality
 
-read_in_dz_pops <- function() {
+read_in_dz_pops_raw <- function() {
   fs::dir_ls(
     glue(
       "/conf/linkage/output/lookups/Unicode/",
@@ -258,6 +260,7 @@ read_in_dz_pops <- function() {
     ) |>
     mutate(year = as.integer(year))
 }
+read_in_dz_pops <- memoise(read_in_dz_pops_raw)
 
 read_in_dz_pops_proxy_year <- function() {
   read_in_dz_pops() |>
@@ -272,7 +275,7 @@ read_in_dz_pops_proxy_year <- function() {
 # Function pulls the latest projections HSCP2019_pop_proj....rds
 # Then joins this with the hscp lookup to match hscp names
 
-read_in_pop_proj <- function() {
+read_in_pop_proj_raw <- function() {
   proj <- fs::dir_ls(
     glue(
       "/conf/linkage/output/lookups/Unicode/",
@@ -294,6 +297,7 @@ read_in_pop_proj <- function() {
 
   left_join(proj, hscp_lkp, by = join_by(hscp2019))
 }
+read_in_pop_proj <- memoise(read_in_pop_proj_raw)
 
 #### Functions for ScotPHO data ####
 


### PR DESCRIPTION
I was looking into something else (maybe coming soon!) and speaking to AI about it, and it noted that some of the functions should / could be cached. It turns out the code changes are minimal, and after running some tests in the background today found that it makes them ~ 20% quicker to run!

### Summary
This PR introduces the [memoise](https://memoise.r-lib.org/) package to cache repeated calls to data loading functions (specifically geography lookups and population files). This significantly reduces redundant I/O operations during the iterative rendering of locality profiles.

### Motivation
The previous profile generation process re-read and re-processed static lookup files (e.g., `read_in_localities`, `read_in_postcodes`) for every single locality iteration. By caching these functions using `memoise`, we read the file once, store the result in memory, and serve the cached result for all subsequent calls.

### Performance Impact
Benchmarking indicates a consistent **~17% reduction in total runtime**.

| Scenario | No Cache (Baseline) | With Cache (`memoise`) | Time Saved | Speedup |
| :--- | :--- | :--- | :--- | :--- |
| **Angus Only** | 265.5s | 220.5s | ~45s | **16.9%** |
| **All Profiles** | 7631.7s (~2.1 hrs) | 6335.5s (~1.7 hrs) | **~21.6 mins** | **17.0%** |

### Technical Changes
* **Modified `Global Script.R`:**
    * Wrapped `read_in_localities`, `read_in_dz_pops`, `read_in_pop_proj`, and `read_in_postcodes` with `memoise::memoise()`.
* **Dependencies:** Added `memoise` to the project library.

### Testing
* Validated that the cached functions return identical data frames to the original functions.
* Benchmarked using `tictoc` on both a single HSCP (Angus) and the full suite of profiles.