### PR TITLE
Move Services HSCP only code out of the locality loop

### DIFF
--- a/Build Profiles.R
+++ b/Build Profiles.R
@@ -42,6 +42,9 @@ for (HSCP in hscp_list) {
     filter(hscp2019name == HSCP) |>
     pull(hscp_locality)
 
+  # Source in HSCP-level scripts
+  source("Services/2a. hscp_services_data_manipulation.R")
+
   # Loop to create the profiles for all the localities in the list
 
   # There are several stages to the profiles:
@@ -64,7 +67,7 @@ for (HSCP in hscp_list) {
     source("Households/Households Code.R")
 
     # Services ----
-    source("Services/2. Services data manipulation & table.R")
+    source("Services/2b. locality_services_table.R")
     source("Services/3. Service HSCP map.R")
 
     # General Health ----

--- a/Services/2a. hscp_services_data_manipulation.R
+++ b/Services/2a. hscp_services_data_manipulation.R
@@ -1,21 +1,20 @@
-############################################################################################# .
-#                                                                                           #
-#                         LOCALITY PROFILES SERVICES MAP & TABLE CODE                       #
-#                                                                                           #
-############################################################################################# .
+# This script prepares the services data at the HSCP level.
+# The locality-specific table is created in "2b. locality_services_table.R".
+# The map is created in script "3. Services HSCP Map".
 
-## Code used to manipulate services data for locality profiles.
-# Also produces a table of what services are in the locality.
-# The map is created in script "3. Services HSCP Map" - this is so that it does not have to run
-# for every locality
+###### 1. Set up ----
+
+## Written by C.Puech
+## Created on 24/02/2020
+## Latest update August 2022 - rewrote parts of code for smoother process
 
 ###### 1. Set up ######
 
 # Change year to be the year in the data folder name
 ext_year <- 2025
 
-## Set Locality (for testing only)
-#LOCALITY <- "Inverness"
+## Set HSCP (for testing only)
+# HSCP <- "Falkirk"
 
 ## Set file path
 #lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
@@ -26,19 +25,14 @@ ext_year <- 2025
 ### Geographical lookups and objects ----
 
 # Locality lookup
-lookup <- read_in_localities(dz_level = TRUE)
-
-# Lookup without datazones
-lookup2 <- read_in_localities()
-
-## Determine HSCP
-HSCP <- as.character(filter(lookup2, hscp_locality == LOCALITY)$hscp2019name)
+lookup <- read_in_localities()
 
 # Get number of localities in HSCP
-n_loc <- count_localities(lookup2, HSCP)
+# This script assumes that 'HSCP' is an object available in the environment
+n_loc <- count_localities(lookup, HSCP)
 
 
-###### 2. Read in services data ######
+###### 2. Read in services data ----
 
 ## Read in Postcode file for latitudes and longitudes
 
@@ -159,57 +153,12 @@ markers_care_home <- care_homes %>%
   filter(hscp2019name == HSCP)
 
 
-###### 4. Table ######
-
-# Subset care which is not Elderly care for table
-other_care_type <- care_homes %>%
-  select(
-    type = care_service,
-    subtype,
-    name = service_name,
-    service_postcode
-  ) %>%
-  filter(type == "Care Home Service") %>%
-  filter(subtype != "Older People") %>%
-  mutate(postcode = gsub(" ", "", service_postcode, fixed = TRUE)) %>%
-  left_join(postcode_lkp, by = "postcode") %>%
-  filter(hscp_locality == LOCALITY)
-
-# Create table
-services_tibble <- tibble(
-  Type = c("Primary Care", "A&E", "", "Care Home", ""),
-  Service = c(
-    "GP Practice",
-    "Emergency Department",
-    "Minor Injuries Unit",
-    "Elderly Care",
-    "Other"
-  ),
-  Number = c(
-    sum(markers_gp[["hscp_locality"]] == LOCALITY),
-    sum(markers_emergency_dep[["hscp_locality"]] == LOCALITY),
-    sum(markers_miu[["hscp_locality"]] == LOCALITY),
-    sum(markers_care_home[["hscp_locality"]] == LOCALITY),
-    nrow(other_care_type)
-  )
-)
-
 # Housekeeping ----
-# These objects are left over after the script is run
-# but don't appear to be used in any 'downstream' process:
-# Main markdown, Summary Table, Excel data tables, SDC output.
-# TODO: Investigate if these can be removed earlier or not created at all.
 rm(
-  care_homes,
-  Clacks_Royal,
   data,
   file,
   hosp_lookup,
-  hosp_postcodes,
-  hosp_types,
   name,
-  other_care_type,
-  postcode_lkp,
   prac,
   services_file_names
 )

--- a/Services/2b. locality_services_table.R
+++ b/Services/2b. locality_services_table.R
@@ -1,0 +1,63 @@
+# Code used to produce a table of what services are in the locality.
+# The data manipulation is done in script "2a. hscp_services_data_manipulation.R".
+# The map is created in script "3. Services HSCP Map".
+
+###### 1. Set up ----
+
+## Set Locality (for testing only)
+# LOCALITY <- "Falkirk West"
+
+## Set file path
+# lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
+
+##Source in functions code
+# source("Master RMarkdown Document & Render Code/Global Script.R")
+
+## Locality lookup
+# lookup <- read_in_localities(dz_level = TRUE)
+
+## Determine HSCP (for testing only)
+# HSCP <- as.character(filter(lookup, hscp_locality == LOCALITY)$hscp2019name)
+
+## Source the HSCP level data for completeness
+# source("Services/2a. hscp_services_data_manipulation.R")
+
+###### 2. Table ----
+
+# Subset care which is not Elderly care for table
+other_care_type <- care_homes %>%
+  select(
+    type = care_service,
+    subtype,
+    name = service_name,
+    service_postcode
+  ) %>%
+  filter(type == "Care Home Service") %>%
+  filter(subtype != "Older People") %>%
+  mutate(postcode = gsub(" ", "", service_postcode, fixed = TRUE)) %>%
+  left_join(postcode_lkp, by = "postcode") %>%
+  filter(hscp_locality == LOCALITY)
+
+# Create table
+services_tibble <- tibble(
+  Type = c("Primary Care", "A&E", "", "Care Home", ""),
+  Service = c(
+    "GP Practice",
+    "Emergency Department",
+    "Minor Injuries Unit",
+    "Elderly Care",
+    "Other"
+  ),
+  Number = c(
+    sum(markers_gp[["hscp_locality"]] == LOCALITY),
+    sum(markers_emergency_dep[["hscp_locality"]] == LOCALITY),
+    sum(markers_miu[["hscp_locality"]] == LOCALITY),
+    sum(markers_care_home[["hscp_locality"]] == LOCALITY),
+    nrow(other_care_type)
+  )
+)
+
+# Housekeeping ----
+rm(
+  other_care_type
+)

--- a/Services/3. Service HSCP map.R
+++ b/Services/3. Service HSCP map.R
@@ -18,8 +18,9 @@
 # slice(1) |>
 #  pull(hscp_locality)
 
-## Source the data manipulation script for services
-source("Services/2. Services data manipulation & table.R")
+# Source the data manipulation scripts for services
+# source("Services/2a. hscp_services_data_manipulation.R")
+# source("Services/2b. locality_services_table.R")
 
 # 1. Set up ----
 
@@ -483,4 +484,23 @@ rm(
   shp_hscp
 )
 
+# Housekeeping ----
+# These objects are left over after the script is run
+# but don't appear to be used in any 'downstream' process:
+# Main markdown, Summary Table, Excel data tables, SDC output.
+# TODO: Investigate if these can be removed earlier or not created at all.
+rm(
+  all_markers,
+  api_key,
+  col_palette,
+  ext_year,
+  hscp_loc,
+  locality_map_id,
+  lookup2,
+  max_lat,
+  max_long,
+  min_lat,
+  min_long,
+  places
+)
 gc()


### PR DESCRIPTION
Some of the code in the Services only depends on HSCP, not LOCALITY, therefore  it doesn't make sense to run it numerous times for each locality in the same HSCP.

This splits the code into two scripts.

I also realised the `lookup` object wasn't being used, so I removed and renamed `lookup2` -> `lookup` which makes much more sense and is in line with other scripts now!
