### PR TITLE
Massively speed up profile creation

### DIFF
--- a/Build Profiles.R
+++ b/Build Profiles.R
@@ -2,6 +2,7 @@ library(knitr)
 library(bookdown)
 library(phstemplates)
 
+rm(list = ls())
 rlang::check_installed(
   pkg = "phstemplates",
   reason = "v1.3.0 is needed to apply sensitivity labels",
@@ -11,8 +12,6 @@ rlang::check_installed(
   }
 )
 
-rm(list = ls())
-
 # Source in functions code
 source("Master RMarkdown Document & Render Code/Global Script.R")
 
@@ -20,14 +19,6 @@ source("Master RMarkdown Document & Render Code/Global Script.R")
 lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 output_dir <- path(lp_path, "Profiles Output")
 
-cover_page_path <- path(
-  lp_path,
-  "templates",
-  "phs-mngtinfo-cover.docx"
-)
-
-tmp_cover_page_path <- file_temp(ext = ".docx")
-file_copy(cover_page_path, tmp_cover_page_path)
 
 # Below creates locality list of all the localities in a chosen HSCP
 lookup <- read_in_localities()
@@ -42,6 +33,30 @@ hscp_list <- "West Dunbartonshire"
 
 # NOTE - This checks that it exactly matches the lookup
 stopifnot(all(hscp_list %in% unique(lookup[["hscp2019name"]])))
+
+# Create temporary local locations
+temp_root <- file_temp(pattern = "lp-profile-build-")
+dir_create(temp_root)
+
+tmp_inputs_dir <- path(temp_root, "inputs")
+tmp_docs_dir <- path(temp_root, "docs")
+
+dir_create(c(tmp_inputs_dir, tmp_docs_dir))
+
+local_lp_bookdown <- path(tmp_inputs_dir, "lp_bookdown")
+dir_copy("lp_bookdown", local_lp_bookdown)
+
+cover_page_path <- path(
+  lp_path,
+  "templates",
+  "phs-mngtinfo-cover.docx"
+)
+
+tmp_cover_page_path <- path(tmp_inputs_dir, "phs-mngtinfo-cover.docx")
+file_copy(cover_page_path, tmp_cover_page_path, overwrite = TRUE)
+
+local_lp_bookdown <- file_temp(pattern = "lp_bookdown-")
+dir_copy("lp_bookdown", local_lp_bookdown)
 
 # Loop over HSCP ----
 # 'looping' over one HSCP is fine.
@@ -93,19 +108,17 @@ for (HSCP in hscp_list) {
     doc_title <- glue(safe_locality, "- Locality Profile")
     output_doc_name <- path_ext_set(doc_title, "docx")
 
+    tmp_document_path <- path(tmp_docs_dir, output_doc_name)
     final_document_path <- path(output_dir, output_doc_name)
-    tmp_document_path <- file_temp(ext = ".docx")
 
-    # Make sure your working directory is the project root
     bookdown::render_book(
-      input = "lp_bookdown",
-      output_dir = path_dir(tmp_document_path),
-      output_file = path_file(tmp_document_path),
+      input = local_lp_bookdown,
+      output_dir = tmp_docs_dir,
+      output_file = output_doc_name,
       new_session = FALSE,
       output_format = "bookdown::word_document2",
       config_file = "_bookdown.yaml"
     )
-
 
 
     orient(tmp_document_path)
@@ -136,4 +149,8 @@ for (HSCP in hscp_list) {
     # Force garbage collection to free up memory
     gc()
   }
+}
+
+if (dir_exists(temp_root)) {
+  dir_delete(temp_root)
 }

--- a/Build Profiles.R
+++ b/Build Profiles.R
@@ -120,9 +120,7 @@ for (HSCP in hscp_list) {
       config_file = "_bookdown.yaml"
     )
 
-
     orient(tmp_document_path)
-
 
     add_cover_page(
       tmp_document_path,

--- a/Build Profiles.R
+++ b/Build Profiles.R
@@ -20,6 +20,15 @@ source("Master RMarkdown Document & Render Code/Global Script.R")
 lp_path <- "/conf/LIST_analytics/West Hub/02 - Scaled Up Work/RMarkdown/Locality Profiles/"
 output_dir <- path(lp_path, "Profiles Output")
 
+cover_page_path <- path(
+  lp_path,
+  "templates",
+  "phs-mngtinfo-cover.docx"
+)
+
+tmp_cover_page_path <- file_temp(ext = ".docx")
+file_copy(cover_page_path, tmp_cover_page_path)
+
 # Below creates locality list of all the localities in a chosen HSCP
 lookup <- read_in_localities()
 
@@ -84,39 +93,43 @@ for (HSCP in hscp_list) {
     doc_title <- glue(safe_locality, "- Locality Profile")
     output_doc_name <- path_ext_set(doc_title, "docx")
 
+    final_document_path <- path(output_dir, output_doc_name)
+    tmp_document_path <- file_temp(ext = ".docx")
+
     # Make sure your working directory is the project root
     bookdown::render_book(
       input = "lp_bookdown",
-      output_dir = output_dir,
-      output_file = output_doc_name,
+      output_dir = path_dir(tmp_document_path),
+      output_file = path_file(tmp_document_path),
       new_session = FALSE,
       output_format = "bookdown::word_document2",
       config_file = "_bookdown.yaml"
     )
 
-    # safe version for file paths
 
-    document_path <- path(output_dir, output_doc_name)
 
-    orient(document_path)
+    orient(tmp_document_path)
 
-    cover_page_path <- path(
-      lp_path,
-      "templates",
-      "phs-mngtinfo-cover.docx"
-    )
 
     add_cover_page(
-      document_path,
-      cover_page_path,
+      tmp_document_path,
+      tmp_cover_page_path,
       main_title
     )
 
     apply_sensitivity_label(
-      document_path,
+      tmp_document_path,
       "OFFICIAL_SENSITIVE_VMO"
     )
 
+    if (file_exists(final_document_path)) {
+      file_delete(final_document_path)
+    }
+
+    file_move(
+      tmp_document_path,
+      final_document_path
+    )
     # End of loop housekeeping ----
     # Clean up the environment by restoring it to the 'pre-loop' state.
     rm(list = setdiff(ls(), loop_env))


### PR DESCRIPTION
This change stages lp_bookdown, the copied cover page, and temporary DOCX outputs in a shared local temp directory instead of rendering from the network drive. On a sample of localities, this reduced mean Bookdown render time from ~296 s to ~16.7 s (≈94% reduction, ~17.7× faster). Total mean runtime per locality is now ~44.9 s including temp infrastructure setup, down from ~329 s previously (≈86% reduction, ~7.3× faster overall).